### PR TITLE
fix(file-version): rename _filename param + workspace_name fallback

### DIFF
--- a/common/procedures/mfs/versioning/file_version_create.sql
+++ b/common/procedures/mfs/versioning/file_version_create.sql
@@ -12,18 +12,24 @@ DELIMITER $
 -- been copied (the path embeds LAST_INSERT_ID()).
 --
 -- Returns: id (auto-increment PK) + version_num for the caller.
+--
+-- Naming note: parameter is `_fname`, NOT `_filename`. MariaDB's
+-- parser treats `_filename` as a charset introducer (there is an
+-- internal `filename` charset used by MyISAM/Aria for disk-safe
+-- filename encoding) and reports a syntax error at the parameter
+-- list. Same pitfall applies to `_binary`, `_utf8`, `_latin1`, etc.
 -- ==============================================================
 
 DROP PROCEDURE IF EXISTS `file_version_create`$
 CREATE PROCEDURE `file_version_create`(
   IN _nid VARCHAR(16),
-  IN _filename VARCHAR(255),
-  IN _filesize BIGINT UNSIGNED,
+  IN _fname VARCHAR(255),
+  IN _filesize BIGINT,
   IN _file_path VARCHAR(1000),
   IN _created_by VARCHAR(16)
 )
 BEGIN
-  DECLARE _version_num INT UNSIGNED;
+  DECLARE _version_num INT;
 
   -- Demote any existing active snapshot for this nid
   UPDATE file_version
@@ -39,7 +45,7 @@ BEGIN
   INSERT INTO file_version
     (nid, version_num, filename, filesize, file_path, created_by, ctime, is_active)
   VALUES
-    (_nid, _version_num, _filename, _filesize, _file_path, _created_by, UNIX_TIMESTAMP(), 1);
+    (_nid, _version_num, _fname, _filesize, _file_path, _created_by, UNIX_TIMESTAMP(), 1);
 
   SELECT LAST_INSERT_ID() AS id, _version_num AS version_num;
 END$

--- a/common/procedures/mfs/versioning/file_version_list.sql
+++ b/common/procedures/mfs/versioning/file_version_list.sql
@@ -22,13 +22,17 @@ BEGIN
     m.mimetype,
     m.parent_id,
     pm.user_filename AS folder_name,
-    e.ident AS workspace_name,
+    -- yp.entity.ident is often NULL on freshly-created hubs; fall back
+    -- through yp.hub.name, then yp.hub.hubname, mirroring the chain used
+    -- by yp.member_list_workspaces.
+    IFNULL(IFNULL(e.ident, h.name), h.hubname) AS workspace_name,
     m.upload_time AS ctime,
     m.publish_time AS mtime,
     COUNT(fv.id) AS version_count
   FROM media m
   LEFT JOIN media pm ON pm.id = m.parent_id
-  LEFT JOIN yp.entity e ON e.id  = _hub_id
+  LEFT JOIN yp.entity e ON e.id = _hub_id
+  LEFT JOIN yp.hub    h ON h.id = _hub_id
   LEFT JOIN file_version fv ON fv.nid = m.id
   WHERE m.status NOT IN ('hidden', 'deleted')
     AND m.category NOT IN ('folder', 'hub', 'root')

--- a/patches/CHANGELOG.md
+++ b/patches/CHANGELOG.md
@@ -12,6 +12,7 @@
 - **New procedures** (`common/procedures/mfs/versioning/`): `file_version_list`, `file_version_get`, `file_version_delete_old`, `file_version_download`, `file_version_create`, `file_version_purge`
 - **Updated**: `common/procedures/mfs/mfs_purge.sql` — cascades file_version row deletion when a media node is permanently purged
 - `file_version_create` is the write hook called from `media.save` / `media.replace` to snapshot the pre-overwrite blob; demotes any prior `is_active=1` row and assigns the next `version_num`
+- ⚠️ Naming pitfall: the proc uses parameter `_fname`, *not* `_filename`. MariaDB's parser treats `_filename` (and `_binary`, `_utf8`, `_latin1`, …) as charset introducers and rejects them as identifiers in stored-procedure parameter declarations. Avoid underscore-prefixed names that collide with registered charsets.
 - Moved from `hub/procedures/admin/` (deleted): `file_version_*` procedures now live under `common/`
 
 ### Hub Channel


### PR DESCRIPTION
file_version_create
- Rename parameter `_filename` -> `_fname`. MariaDB's parser treats `_filename` as a charset introducer (there is an internal `filename` charset used by MyISAM/Aria for disk-safe filename encoding) and reports a 1064 syntax error at the parameter list, even though the proc body and structure are otherwise identical to file_version_list which parses cleanly. Same pitfall applies to `_binary`, `_utf8`, `_latin1`, etc. Header comment documents the trap.
- Drop UNSIGNED from BIGINT and INT in the parameter list and DECLARE — the other versioning procs use plain BIGINT/TINYINT for the same fields and storing UNSIGNED via an int param works via implicit coercion within the domain (filesize >= 0, version_num >= 1).

file_version_list
- workspace_name was returning NULL on freshly-created hubs because yp.entity.ident is often NULL there. Mirror the fallback chain used by yp.member_list_workspaces: IFNULL(IFNULL(e.ident, h.name), h.hubname). Adds a LEFT JOIN to yp.hub on the hub_id input parameter.