### PR TITLE
Google Drive migration — oauth_accounts scope/expires (schema)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "dev": "drumee-server-devel"
   },
   "dependencies": {
+    "@drumee/server-core": "^1.1.76",
     "@drumee/server-dev-tools": "^1.1.32",
     "@drumee/server-essentials": "^1.2.44",
     "minimist": "^1.2.8",

--- a/patches/changelog.txt
+++ b/patches/changelog.txt
@@ -1,3 +1,6 @@
+2026-05-25
+  yellow_page/patches/2026-05-25-drop-migration-jobs.sql
+
 2026-05-23
   yellow_page/patches/2026-05-23-gdrive-migration.sql
   yellow_page/tables/oauth_accounts.sql

--- a/patches/changelog.txt
+++ b/patches/changelog.txt
@@ -1,3 +1,7 @@
+2026-05-23
+  yellow_page/patches/2026-05-23-gdrive-migration.sql
+  yellow_page/tables/oauth_accounts.sql
+
 2026-05-21
   drumate/patches/fix_informed_contacts.sql
 

--- a/patches/changelog.txt
+++ b/patches/changelog.txt
@@ -1,3 +1,6 @@
+2026-05-29
+  yellow_page/tables/oauth_accounts.sql
+
 2026-05-25
   yellow_page/patches/2026-05-25-drop-migration-jobs.sql
 

--- a/patches/manifest.txt
+++ b/patches/manifest.txt
@@ -24,3 +24,6 @@
   yellow_page/procedures/conference/conference_invite.sql
   yellow_page/procedures/drumate/drumate_update_profile.sql
   drumate/patches/fix_informed_contacts.sql
+  yellow_page/tables/oauth_accounts.sql
+  yellow_page/patches/2026-05-23-gdrive-migration.sql
+  yellow_page/patches/2026-05-25-drop-migration-jobs.sql

--- a/yellow_page/patches/2026-05-23-gdrive-migration.sql
+++ b/yellow_page/patches/2026-05-23-gdrive-migration.sql
@@ -1,0 +1,67 @@
+-- ============================================================================
+-- 2026-05-23 — Google Drive migration support
+-- 1. ALTER oauth_accounts: add scope + expires_at (NULL = unknown / legacy)
+-- 2. CREATE migration_jobs: per-user, per-provider job tracking
+-- Idempotent: safe to re-apply.
+-- ============================================================================
+
+-- 1. ALTER oauth_accounts -----------------------------------------------------
+
+DELIMITER $$
+
+DROP PROCEDURE IF EXISTS `_add_col_if_missing` $$
+CREATE PROCEDURE `_add_col_if_missing`(
+  IN tbl VARCHAR(64),
+  IN col VARCHAR(64),
+  IN ddl VARCHAR(512)
+)
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = DATABASE()
+      AND table_name = tbl
+      AND column_name = col
+  ) THEN
+    SET @s = CONCAT('ALTER TABLE `', tbl, '` ADD COLUMN ', ddl);
+    PREPARE stmt FROM @s; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+  END IF;
+END $$
+
+DELIMITER ;
+
+CALL _add_col_if_missing('oauth_accounts', 'scope',
+  '`scope` VARCHAR(512) DEFAULT NULL COMMENT ''Space-separated OAuth scope list'' AFTER `refresh_token`');
+
+CALL _add_col_if_missing('oauth_accounts', 'expires_at',
+  '`expires_at` INT(10) UNSIGNED DEFAULT NULL COMMENT ''Unix ts of access_token expiry'' AFTER `scope`');
+
+DROP PROCEDURE IF EXISTS `_add_col_if_missing`;
+
+-- 2. CREATE migration_jobs ----------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS `migration_jobs` (
+  `id`                    BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  -- Match `oauth_accounts.user_id` (utf8mb4_general_ci) — that FK to
+  -- entity.id already works on stage, so this is the proven-good
+  -- collation for entity-id columns regardless of what entity.sql says.
+  `user_id`               VARCHAR(16) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL,
+  `provider`              ENUM('google','dropbox','onedrive') NOT NULL,
+  `source_folder_id`      VARCHAR(255) NOT NULL DEFAULT 'root',
+  `dest_hub_id`           VARCHAR(16) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL,
+  `dest_nid`              VARCHAR(16) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL,
+  `status`                ENUM('queued','running','done','failed','cancelled') NOT NULL DEFAULT 'queued',
+  `conflict_policy`       ENUM('skip','overwrite','rename') NOT NULL DEFAULT 'skip',
+  `include_shared_drives` TINYINT(1) NOT NULL DEFAULT 0,
+  `total_files`           INT UNSIGNED NOT NULL DEFAULT 0,
+  `processed_files`       INT UNSIGNED NOT NULL DEFAULT 0,
+  `total_folders`         INT UNSIGNED NOT NULL DEFAULT 0,
+  `errors_json`           MEDIUMTEXT NULL,
+  `started_at`            INT UNSIGNED NULL,
+  `finished_at`           INT UNSIGNED NULL,
+  `ctime`                 INT UNSIGNED NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `idx_user_status`     (`user_id`, `status`),
+  KEY `idx_provider_user`   (`provider`, `user_id`),
+  CONSTRAINT `fk_migration_user` FOREIGN KEY (`user_id`)
+    REFERENCES `entity` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;

--- a/yellow_page/patches/2026-05-23-gdrive-migration.sql
+++ b/yellow_page/patches/2026-05-23-gdrive-migration.sql
@@ -1,11 +1,12 @@
 -- ============================================================================
 -- 2026-05-23 — Google Drive migration support
--- 1. ALTER oauth_accounts: add scope + expires_at (NULL = unknown / legacy)
--- 2. CREATE migration_jobs: per-user, per-provider job tracking
+-- ALTER oauth_accounts: add scope + expires_at (NULL = unknown / legacy)
 -- Idempotent: safe to re-apply.
+--
+-- NOTE: An earlier revision of this patch also CREATEd a `migration_jobs`
+-- table. The architecture moved to Bull-only (job state lives in Redis),
+-- so the table was dropped via patches/2026-05-25-drop-migration-jobs.sql.
 -- ============================================================================
-
--- 1. ALTER oauth_accounts -----------------------------------------------------
 
 DELIMITER $$
 
@@ -36,32 +37,3 @@ CALL _add_col_if_missing('oauth_accounts', 'expires_at',
   '`expires_at` INT(10) UNSIGNED DEFAULT NULL COMMENT ''Unix ts of access_token expiry'' AFTER `scope`');
 
 DROP PROCEDURE IF EXISTS `_add_col_if_missing`;
-
--- 2. CREATE migration_jobs ----------------------------------------------------
-
-CREATE TABLE IF NOT EXISTS `migration_jobs` (
-  `id`                    BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
-  -- Match `oauth_accounts.user_id` (utf8mb4_general_ci) — that FK to
-  -- entity.id already works on stage, so this is the proven-good
-  -- collation for entity-id columns regardless of what entity.sql says.
-  `user_id`               VARCHAR(16) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL,
-  `provider`              ENUM('google','dropbox','onedrive') NOT NULL,
-  `source_folder_id`      VARCHAR(255) NOT NULL DEFAULT 'root',
-  `dest_hub_id`           VARCHAR(16) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL,
-  `dest_nid`              VARCHAR(16) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL,
-  `status`                ENUM('queued','running','done','failed','cancelled') NOT NULL DEFAULT 'queued',
-  `conflict_policy`       ENUM('skip','overwrite','rename') NOT NULL DEFAULT 'skip',
-  `include_shared_drives` TINYINT(1) NOT NULL DEFAULT 0,
-  `total_files`           INT UNSIGNED NOT NULL DEFAULT 0,
-  `processed_files`       INT UNSIGNED NOT NULL DEFAULT 0,
-  `total_folders`         INT UNSIGNED NOT NULL DEFAULT 0,
-  `errors_json`           MEDIUMTEXT NULL,
-  `started_at`            INT UNSIGNED NULL,
-  `finished_at`           INT UNSIGNED NULL,
-  `ctime`                 INT UNSIGNED NOT NULL,
-  PRIMARY KEY (`id`),
-  KEY `idx_user_status`     (`user_id`, `status`),
-  KEY `idx_provider_user`   (`provider`, `user_id`),
-  CONSTRAINT `fk_migration_user` FOREIGN KEY (`user_id`)
-    REFERENCES `entity` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;

--- a/yellow_page/patches/2026-05-25-drop-migration-jobs.sql
+++ b/yellow_page/patches/2026-05-25-drop-migration-jobs.sql
@@ -1,0 +1,14 @@
+-- ============================================================================
+-- 2026-05-25 — Drop migration_jobs table (architecture changed)
+--
+-- The first cut of the Google Drive migration feature used a MariaDB
+-- `migration_jobs` table for per-job state. The architecture was revised
+-- to be Bull-only — job state now lives in Redis (`job.progress` + `job.
+-- returnvalue` + Bull's own state machine). The table is no longer
+-- referenced by any service or worker.
+--
+-- Drop is idempotent and safe: by the time this patch runs, no code
+-- writes to or reads from migration_jobs.
+-- ============================================================================
+
+DROP TABLE IF EXISTS `migration_jobs`;

--- a/yellow_page/tables/oauth_accounts.sql
+++ b/yellow_page/tables/oauth_accounts.sql
@@ -7,6 +7,8 @@ CREATE TABLE IF NOT EXISTS  IF NOT EXISTS `oauth_accounts` (
   `email` varchar(255) NOT NULL,
   `access_token` text DEFAULT NULL,
   `refresh_token` text DEFAULT NULL,
+  `scope` varchar(512) DEFAULT NULL COMMENT 'Space-separated OAuth scope list returned at exchange',
+  `expires_at` int(10) unsigned DEFAULT NULL COMMENT 'Unix timestamp when access_token expires (refresh after)',
   `ctime` int(10) unsigned NOT NULL DEFAULT 0 COMMENT 'Unix timestamp (created_at)',
   `mtime` int(10) unsigned NOT NULL DEFAULT 0 COMMENT 'Unix timestamp (updated_at)',
   PRIMARY KEY (`id`),

--- a/yellow_page/tables/oauth_accounts.sql
+++ b/yellow_page/tables/oauth_accounts.sql
@@ -1,5 +1,5 @@
 -- File: ~/schemas/yellow_page/tables/001_create_oauth_accounts.sql
-CREATE TABLE IF NOT EXISTS  IF NOT EXISTS `oauth_accounts` (
+CREATE TABLE IF NOT EXISTS `oauth_accounts` (
   `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
   `user_id` varchar(16) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL COMMENT 'Reference to yp.entity.id',
   `provider` enum('google','apple','dropbox') CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL COMMENT 'OAuth provider name',


### PR DESCRIPTION
Schema cho Google Drive → Drumee migration.

- **oauth_accounts**: thêm cột `scope` + `expires_at` (ALTER idempotent) + sửa lại `CREATE TABLE`; UNIQUE `(provider, provider_user_id)` để upsert.
- **redirect_state** (set/get) cho vòng round-trip state của OAuth elevation.
- **Bull-only**: bỏ bảng `migration_jobs` (job state nằm trong Redis).

Companion PRs: drumee/ui-team `feat/migrate-gdrive-popup-launcher`, drumee/server-team `feat/gdrive-migration-worker`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)