### PR TITLE
feat(secure-share): add secure_share_token table, stored procedures, and patches

### DIFF
--- a/yellow_page/patches/add_active_socket_id_to_secure_share_token.sql
+++ b/yellow_page/patches/add_active_socket_id_to_secure_share_token.sql
@@ -1,0 +1,6 @@
+-- Patch: add active_socket_id to secure_share_token so revoke can target the
+-- recipient's WebSocket socket directly rather than relying on entity_sockets().
+-- Safe to run multiple times (ADD COLUMN IF NOT EXISTS, MariaDB 10.3+).
+
+ALTER TABLE `secure_share_token`
+  ADD COLUMN IF NOT EXISTS `active_socket_id` VARCHAR(32) DEFAULT NULL AFTER `password_hash`;

--- a/yellow_page/patches/add_password_hash_to_secure_share_token.sql
+++ b/yellow_page/patches/add_password_hash_to_secure_share_token.sql
@@ -1,0 +1,6 @@
+-- Patch: add password_hash column to secure_share_token.
+-- Allows senders to optionally protect a share link with a bcrypt/pbkdf2 password.
+-- Safe to run multiple times (ADD COLUMN IF NOT EXISTS is idempotent in MariaDB 10.3+).
+
+ALTER TABLE `secure_share_token`
+  ADD COLUMN IF NOT EXISTS `password_hash` VARCHAR(255) DEFAULT NULL AFTER `domain_restriction`;

--- a/yellow_page/patches/create_secure_share_token.sql
+++ b/yellow_page/patches/create_secure_share_token.sql
@@ -1,0 +1,23 @@
+-- Patch: add secure_share_token table for per-email unique secure share links.
+-- Safe to run multiple times (CREATE TABLE IF NOT EXISTS).
+
+CREATE TABLE IF NOT EXISTS `secure_share_token` (
+  `sys_id`             int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `id`                 varchar(80)      NOT NULL,
+  `hub_id`             varchar(16)      CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL,
+  `node_id`            varchar(16)      CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL,
+  `creator_id`         varchar(16)      CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL,
+  `recipient_email`    varchar(512)     NOT NULL,
+  `domain_restriction` varchar(255)     DEFAULT NULL,
+  `expiry_time`        int(11)          NOT NULL DEFAULT 0,
+  `revoked_at`         int(11)          DEFAULT NULL,
+  `access_count`       int(11) unsigned NOT NULL DEFAULT 0,
+  `last_accessed`      int(11)          DEFAULT NULL,
+  `ctime`              int(11)          NOT NULL DEFAULT unix_timestamp(),
+  PRIMARY KEY (`sys_id`),
+  UNIQUE KEY `id`            (`id`),
+  KEY        `idx_hub_node`  (`hub_id`, `node_id`),
+  KEY        `idx_creator`   (`creator_id`),
+  KEY        `idx_recipient` (`recipient_email`(191)),
+  KEY        `idx_ctime`     (`ctime`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;

--- a/yellow_page/procedures/secure_share/secure_share_access_log.sql
+++ b/yellow_page/procedures/secure_share/secure_share_access_log.sql
@@ -2,8 +2,9 @@ DELIMITER $
 
 DROP PROCEDURE IF EXISTS `secure_share_access_log`$
 CREATE PROCEDURE `secure_share_access_log`(
-  IN _token    VARCHAR(80),
-  IN _actor_id VARCHAR(16) CHARACTER SET ascii
+  IN _token     VARCHAR(80),
+  IN _actor_id  VARCHAR(16) CHARACTER SET ascii,
+  IN _socket_id VARCHAR(32)
 )
 BEGIN
   DECLARE _hub_id     VARCHAR(16) CHARACTER SET ascii;
@@ -19,8 +20,9 @@ BEGIN
 
   IF _hub_id IS NOT NULL THEN
     UPDATE `secure_share_token`
-    SET    access_count  = access_count + 1,
-           last_accessed = UNIX_TIMESTAMP()
+    SET    access_count     = access_count + 1,
+           last_accessed    = UNIX_TIMESTAMP(),
+           active_socket_id = IF(_socket_id IS NOT NULL AND _socket_id != '', _socket_id, active_socket_id)
     WHERE  id = _token;
 
     SELECT

--- a/yellow_page/procedures/secure_share/secure_share_access_log.sql
+++ b/yellow_page/procedures/secure_share/secure_share_access_log.sql
@@ -1,0 +1,36 @@
+DELIMITER $
+
+DROP PROCEDURE IF EXISTS `secure_share_access_log`$
+CREATE PROCEDURE `secure_share_access_log`(
+  IN _token    VARCHAR(80),
+  IN _actor_id VARCHAR(16) CHARACTER SET ascii
+)
+BEGIN
+  DECLARE _hub_id     VARCHAR(16) CHARACTER SET ascii;
+  DECLARE _node_id    VARCHAR(16) CHARACTER SET ascii;
+  DECLARE _creator_id VARCHAR(16) CHARACTER SET ascii;
+  DECLARE _email      VARCHAR(512);
+
+  SELECT hub_id, node_id, creator_id, recipient_email
+  INTO   _hub_id, _node_id, _creator_id, _email
+  FROM   `secure_share_token`
+  WHERE  id = _token
+  LIMIT  1;
+
+  IF _hub_id IS NOT NULL THEN
+    UPDATE `secure_share_token`
+    SET    access_count  = access_count + 1,
+           last_accessed = UNIX_TIMESTAMP()
+    WHERE  id = _token;
+
+    SELECT
+      _hub_id     AS hub_id,
+      _node_id    AS node_id,
+      _creator_id AS creator_id,
+      _email      AS recipient_email,
+      _actor_id   AS actor_id
+    ;
+  END IF;
+END$
+
+DELIMITER ;

--- a/yellow_page/procedures/secure_share/secure_share_create.sql
+++ b/yellow_page/procedures/secure_share/secure_share_create.sql
@@ -1,0 +1,44 @@
+DELIMITER $
+
+DROP PROCEDURE IF EXISTS `secure_share_create`$
+CREATE PROCEDURE `secure_share_create`(
+  IN _token              VARCHAR(80),
+  IN _hub_id             VARCHAR(16) CHARACTER SET ascii,
+  IN _node_id            VARCHAR(16) CHARACTER SET ascii,
+  IN _creator_id         VARCHAR(16) CHARACTER SET ascii,
+  IN _recipient_email    VARCHAR(512),
+  IN _domain_restriction VARCHAR(255),
+  IN _expiry_hours       INT
+)
+BEGIN
+  DECLARE _expiry_time INT DEFAULT 0;
+
+  IF _expiry_hours > 0 THEN
+    SET _expiry_time = UNIX_TIMESTAMP() + (_expiry_hours * 3600);
+  END IF;
+
+  INSERT INTO `secure_share_token`
+    (`id`, `hub_id`, `node_id`, `creator_id`, `recipient_email`,
+     `domain_restriction`, `expiry_time`, `ctime`)
+  VALUES
+    (_token, _hub_id, _node_id, _creator_id,
+     LOWER(TRIM(_recipient_email)),
+     IF(TRIM(IFNULL(_domain_restriction, '')) = '', NULL, LOWER(TRIM(_domain_restriction))),
+     _expiry_time, UNIX_TIMESTAMP());
+
+  SELECT
+    s.sys_id,
+    s.id,
+    s.hub_id,
+    s.node_id,
+    s.creator_id,
+    s.recipient_email,
+    s.domain_restriction,
+    s.expiry_time,
+    s.access_count,
+    s.ctime
+  FROM `secure_share_token` s
+  WHERE s.id = _token;
+END$
+
+DELIMITER ;

--- a/yellow_page/procedures/secure_share/secure_share_create.sql
+++ b/yellow_page/procedures/secure_share/secure_share_create.sql
@@ -8,7 +8,8 @@ CREATE PROCEDURE `secure_share_create`(
   IN _creator_id         VARCHAR(16) CHARACTER SET ascii,
   IN _recipient_email    VARCHAR(512),
   IN _domain_restriction VARCHAR(255),
-  IN _expiry_hours       INT
+  IN _expiry_hours       INT,
+  IN _password_hash      VARCHAR(255)
 )
 BEGIN
   DECLARE _expiry_time INT DEFAULT 0;
@@ -19,11 +20,12 @@ BEGIN
 
   INSERT INTO `secure_share_token`
     (`id`, `hub_id`, `node_id`, `creator_id`, `recipient_email`,
-     `domain_restriction`, `expiry_time`, `ctime`)
+     `domain_restriction`, `password_hash`, `expiry_time`, `ctime`)
   VALUES
     (_token, _hub_id, _node_id, _creator_id,
      LOWER(TRIM(_recipient_email)),
      IF(TRIM(IFNULL(_domain_restriction, '')) = '', NULL, LOWER(TRIM(_domain_restriction))),
+     IF(TRIM(IFNULL(_password_hash, '')) = '', NULL, _password_hash),
      _expiry_time, UNIX_TIMESTAMP());
 
   SELECT

--- a/yellow_page/procedures/secure_share/secure_share_delete.sql
+++ b/yellow_page/procedures/secure_share/secure_share_delete.sql
@@ -1,0 +1,21 @@
+DELIMITER $
+
+DROP PROCEDURE IF EXISTS `secure_share_delete`$
+CREATE PROCEDURE `secure_share_delete`(
+  IN _token      VARCHAR(80),
+  IN _creator_id VARCHAR(16) CHARACTER SET ascii
+)
+BEGIN
+  -- Only hard-delete tokens that are already revoked or expired; never delete active ones.
+  DELETE FROM `secure_share_token`
+  WHERE  id         = _token
+    AND  creator_id = _creator_id
+    AND  (
+      revoked_at IS NOT NULL
+      OR (expiry_time > 0 AND UNIX_TIMESTAMP() > expiry_time)
+    );
+
+  SELECT ROW_COUNT() AS deleted;
+END$
+
+DELIMITER ;

--- a/yellow_page/procedures/secure_share/secure_share_info.sql
+++ b/yellow_page/procedures/secure_share/secure_share_info.sql
@@ -48,6 +48,7 @@ BEGIN
       s.creator_id        AS sender_id,
       s.recipient_email,
       s.domain_restriction,
+      s.password_hash,
       s.expiry_time,
       s.access_count,
       s.last_accessed,
@@ -56,12 +57,12 @@ BEGIN
       _fullname           AS `name`,
       _fullname           AS `sender`,
       _hub_name           AS title,
-      0                   AS require_password,
+      IF(s.password_hash IS NOT NULL, 1, 0) AS require_password,
       0                   AS is_public,
       1                   AS is_secure,
       CASE
-        WHEN _revoked_at IS NOT NULL                            THEN 'TICKET_REVOKED'
-        WHEN _expiry_time > 0 AND UNIX_TIMESTAMP() > _expiry_time THEN 'TICKET_EXPIRED'
+        WHEN _revoked_at IS NOT NULL                                THEN 'TICKET_REVOKED'
+        WHEN _expiry_time > 0 AND UNIX_TIMESTAMP() > _expiry_time  THEN 'TICKET_EXPIRED'
         ELSE 'TICKET_OK'
       END                 AS validity
     FROM `secure_share_token` s

--- a/yellow_page/procedures/secure_share/secure_share_info.sql
+++ b/yellow_page/procedures/secure_share/secure_share_info.sql
@@ -1,0 +1,72 @@
+DELIMITER $
+
+DROP PROCEDURE IF EXISTS `secure_share_info`$
+CREATE PROCEDURE `secure_share_info`(
+  IN _token VARCHAR(80)
+)
+BEGIN
+  DECLARE _hub_id            VARCHAR(16) CHARACTER SET ascii;
+  DECLARE _node_id           VARCHAR(16) CHARACTER SET ascii;
+  DECLARE _creator_id        VARCHAR(16) CHARACTER SET ascii;
+  DECLARE _revoked_at        INT(11)     DEFAULT NULL;
+  DECLARE _expiry_time       INT         DEFAULT 0;
+  DECLARE _db_name           VARCHAR(50);
+  DECLARE _fullname          VARCHAR(150);
+  DECLARE _hub_name          VARCHAR(150);
+
+  SELECT
+    s.hub_id,
+    s.node_id,
+    s.creator_id,
+    s.revoked_at,
+    s.expiry_time
+  INTO
+    _hub_id, _node_id, _creator_id, _revoked_at, _expiry_time
+  FROM `secure_share_token` s
+  WHERE s.id = _token
+  LIMIT 1;
+
+  IF _hub_id IS NULL THEN
+    SELECT 1 AS failed, 'TICKET_INVALID' AS validity;
+  ELSE
+    SELECT db_name FROM entity WHERE id = _hub_id INTO _db_name;
+
+    SELECT CONCAT(firstname, ' ', IFNULL(lastname, ''))
+    FROM   drumate
+    WHERE  id = _creator_id
+    INTO   _fullname;
+
+    SELECT name FROM hub WHERE id = _hub_id INTO _hub_name;
+
+    SELECT
+      s.sys_id,
+      s.id                AS token,
+      s.hub_id,
+      s.node_id,
+      s.node_id           AS nid,
+      s.creator_id,
+      s.creator_id        AS sender_id,
+      s.recipient_email,
+      s.domain_restriction,
+      s.expiry_time,
+      s.access_count,
+      s.last_accessed,
+      s.ctime,
+      _db_name            AS db_name,
+      _fullname           AS `name`,
+      _fullname           AS `sender`,
+      _hub_name           AS title,
+      0                   AS require_password,
+      0                   AS is_public,
+      1                   AS is_secure,
+      CASE
+        WHEN _revoked_at IS NOT NULL                            THEN 'TICKET_REVOKED'
+        WHEN _expiry_time > 0 AND UNIX_TIMESTAMP() > _expiry_time THEN 'TICKET_EXPIRED'
+        ELSE 'TICKET_OK'
+      END                 AS validity
+    FROM `secure_share_token` s
+    WHERE s.id = _token;
+  END IF;
+END$
+
+DELIMITER ;

--- a/yellow_page/procedures/secure_share/secure_share_list.sql
+++ b/yellow_page/procedures/secure_share/secure_share_list.sql
@@ -1,0 +1,35 @@
+DELIMITER $
+
+DROP PROCEDURE IF EXISTS `secure_share_list`$
+CREATE PROCEDURE `secure_share_list`(
+  IN _hub_id     VARCHAR(16) CHARACTER SET ascii,
+  IN _node_id    VARCHAR(16) CHARACTER SET ascii,
+  IN _creator_id VARCHAR(16) CHARACTER SET ascii
+)
+BEGIN
+  SELECT
+    s.sys_id,
+    s.id,
+    s.hub_id,
+    s.node_id,
+    s.creator_id,
+    s.recipient_email,
+    s.domain_restriction,
+    s.expiry_time,
+    s.revoked_at,
+    s.access_count,
+    s.last_accessed,
+    s.ctime,
+    CASE
+      WHEN s.revoked_at IS NOT NULL                               THEN 'revoked'
+      WHEN s.expiry_time > 0 AND UNIX_TIMESTAMP() > s.expiry_time THEN 'expired'
+      ELSE 'active'
+    END AS `status`
+  FROM  `secure_share_token` s
+  WHERE  s.hub_id     = _hub_id
+    AND  s.node_id    = _node_id
+    AND  s.creator_id = _creator_id
+  ORDER BY s.ctime DESC;
+END$
+
+DELIMITER ;

--- a/yellow_page/procedures/secure_share/secure_share_revoke.sql
+++ b/yellow_page/procedures/secure_share/secure_share_revoke.sql
@@ -23,7 +23,8 @@ BEGIN
     s.recipient_email,
     s.revoked_at,
     s.access_count,
-    s.last_accessed
+    s.last_accessed,
+    s.active_socket_id
   FROM `secure_share_token` s
   WHERE  s.id         = _token
     AND  s.creator_id = _creator_id

--- a/yellow_page/procedures/secure_share/secure_share_revoke.sql
+++ b/yellow_page/procedures/secure_share/secure_share_revoke.sql
@@ -1,0 +1,33 @@
+DELIMITER $
+
+DROP PROCEDURE IF EXISTS `secure_share_revoke`$
+CREATE PROCEDURE `secure_share_revoke`(
+  IN _token      VARCHAR(80),
+  IN _creator_id VARCHAR(16) CHARACTER SET ascii
+)
+BEGIN
+  UPDATE `secure_share_token`
+  SET    revoked_at = UNIX_TIMESTAMP()
+  WHERE  id         = _token
+    AND  creator_id = _creator_id
+    AND  revoked_at IS NULL;
+
+  -- Only return the row when the UPDATE actually set revoked_at (i.e. owned by this creator).
+  -- An empty result tells the caller the revoke did not happen.
+  SELECT
+    s.sys_id,
+    s.id,
+    s.hub_id,
+    s.node_id,
+    s.creator_id,
+    s.recipient_email,
+    s.revoked_at,
+    s.access_count,
+    s.last_accessed
+  FROM `secure_share_token` s
+  WHERE  s.id         = _token
+    AND  s.creator_id = _creator_id
+    AND  s.revoked_at IS NOT NULL;
+END$
+
+DELIMITER ;

--- a/yellow_page/tables/secure_share_token.sql
+++ b/yellow_page/tables/secure_share_token.sql
@@ -6,6 +6,7 @@ CREATE TABLE IF NOT EXISTS `secure_share_token` (
   `creator_id`         varchar(16)      CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL,
   `recipient_email`    varchar(512)     NOT NULL,
   `domain_restriction` varchar(255)     DEFAULT NULL,
+  `password_hash`      varchar(255)     DEFAULT NULL,
   `expiry_time`        int(11)          NOT NULL DEFAULT 0,
   `revoked_at`         int(11)          DEFAULT NULL,
   `access_count`       int(11) unsigned NOT NULL DEFAULT 0,

--- a/yellow_page/tables/secure_share_token.sql
+++ b/yellow_page/tables/secure_share_token.sql
@@ -7,6 +7,7 @@ CREATE TABLE IF NOT EXISTS `secure_share_token` (
   `recipient_email`    varchar(512)     NOT NULL,
   `domain_restriction` varchar(255)     DEFAULT NULL,
   `password_hash`      varchar(255)     DEFAULT NULL,
+  `active_socket_id`   varchar(32)      DEFAULT NULL,
   `expiry_time`        int(11)          NOT NULL DEFAULT 0,
   `revoked_at`         int(11)          DEFAULT NULL,
   `access_count`       int(11) unsigned NOT NULL DEFAULT 0,

--- a/yellow_page/tables/secure_share_token.sql
+++ b/yellow_page/tables/secure_share_token.sql
@@ -1,0 +1,20 @@
+CREATE TABLE IF NOT EXISTS `secure_share_token` (
+  `sys_id`             int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `id`                 varchar(80)      NOT NULL,
+  `hub_id`             varchar(16)      CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL,
+  `node_id`            varchar(16)      CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL,
+  `creator_id`         varchar(16)      CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL,
+  `recipient_email`    varchar(512)     NOT NULL,
+  `domain_restriction` varchar(255)     DEFAULT NULL,
+  `expiry_time`        int(11)          NOT NULL DEFAULT 0,
+  `revoked_at`         int(11)          DEFAULT NULL,
+  `access_count`       int(11) unsigned NOT NULL DEFAULT 0,
+  `last_accessed`      int(11)          DEFAULT NULL,
+  `ctime`              int(11)          NOT NULL DEFAULT unix_timestamp(),
+  PRIMARY KEY (`sys_id`),
+  UNIQUE KEY `id`            (`id`),
+  KEY        `idx_hub_node`  (`hub_id`, `node_id`),
+  KEY        `idx_creator`   (`creator_id`),
+  KEY        `idx_recipient` (`recipient_email`(191)),
+  KEY        `idx_ctime`     (`ctime`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;


### PR DESCRIPTION
## What

Adds all database schema objects required by the Secure Share feature — the entire YP database layer for per-email unique share tokens.

### New table
- `yellow_page/tables/secure_share_token.sql` — stores share tokens with recipient email, optional password hash, domain restriction, expiry, revoke state, and active recipient socket ID

### New stored procedures
| Procedure | Purpose |
|---|---|
| `secure_share_create` | Insert token; accepts optional `_password_hash` (8th param) |
| `secure_share_info` | Read token validity; returns `require_password` flag + `password_hash` for server-side verification |
| `secure_share_list` | List all tokens for a node (sender's share list) |
| `secure_share_revoke` | Soft-delete (`revoked_at`); returns `active_socket_id` for direct WebSocket broadcast to recipient |
| `secure_share_delete` | Hard-delete (only if already revoked or expired) |
| `secure_share_access_log` | Increment `access_count`, update `last_accessed` and store `active_socket_id` — called on every successful recipient access |

### Patches (all idempotent — safe to re-run)
| Patch | What it does |
|---|---|
| `create_secure_share_token.sql` | `CREATE TABLE IF NOT EXISTS` |
| `add_password_hash_to_secure_share_token.sql` | `ADD COLUMN IF NOT EXISTS password_hash VARCHAR(255)` |
| `add_active_socket_id_to_secure_share_token.sql` | `ADD COLUMN IF NOT EXISTS active_socket_id VARCHAR(32)` — stores recipient WebSocket socket_id for real-time revoke |

## Deploy order ⚠️

**Apply all patches before restarting the server.** The updated `secure_share_create` proc expects 8 args — calling it against the old 7-arg version causes a silent failure.

```bash
cd ~/schemas
bin/patch-from-file yellow_page/patches/create_secure_share_token.sql yp
bin/patch-from-file yellow_page/patches/add_password_hash_to_secure_share_token.sql yp
bin/patch-from-file yellow_page/patches/add_active_socket_id_to_secure_share_token.sql yp
bin/patch-from-file yellow_page/procedures/secure_share/secure_share_create.sql yp
bin/patch-from-file yellow_page/procedures/secure_share/secure_share_info.sql yp
bin/patch-from-file yellow_page/procedures/secure_share/secure_share_list.sql yp
bin/patch-from-file yellow_page/procedures/secure_share/secure_share_revoke.sql yp
bin/patch-from-file yellow_page/procedures/secure_share/secure_share_delete.sql yp
bin/patch-from-file yellow_page/procedures/secure_share/secure_share_access_log.sql yp
```

## Test plan
- [ ] All patches apply without error on a clean YP database
- [ ] `DESCRIBE secure_share_token` shows `password_hash` and `active_socket_id` columns
- [ ] `SHOW CREATE PROCEDURE secure_share_create` shows 8 IN parameters
- [ ] `secure_share_info` returns `require_password = 1` for a token with a hash set, `0` for one without
- [ ] `secure_share_revoke` returns `active_socket_id` in the result row