### PR TITLE
refactor(secure-share): secure_share_create — single JSON arg (per Somanos review)

### DIFF
--- a/yellow_page/procedures/secure_share/secure_share_create.sql
+++ b/yellow_page/procedures/secure_share/secure_share_create.sql
@@ -2,17 +2,27 @@ DELIMITER $
 
 DROP PROCEDURE IF EXISTS `secure_share_create`$
 CREATE PROCEDURE `secure_share_create`(
-  IN _token              VARCHAR(80),
-  IN _hub_id             VARCHAR(16) CHARACTER SET ascii,
-  IN _node_id            VARCHAR(16) CHARACTER SET ascii,
-  IN _creator_id         VARCHAR(16) CHARACTER SET ascii,
-  IN _recipient_email    VARCHAR(512),
-  IN _domain_restriction VARCHAR(255),
-  IN _expiry_hours       INT,
-  IN _password_hash      VARCHAR(255)
+  IN _args JSON
 )
 BEGIN
-  DECLARE _expiry_time INT DEFAULT 0;
+  DECLARE _token              VARCHAR(80);
+  DECLARE _hub_id             VARCHAR(16) CHARACTER SET ascii;
+  DECLARE _node_id            VARCHAR(16) CHARACTER SET ascii;
+  DECLARE _creator_id         VARCHAR(16) CHARACTER SET ascii;
+  DECLARE _recipient_email    VARCHAR(512);
+  DECLARE _domain_restriction VARCHAR(255);
+  DECLARE _password_hash      VARCHAR(255);
+  DECLARE _expiry_hours       INT DEFAULT 0;
+  DECLARE _expiry_time        INT DEFAULT 0;
+
+  SELECT JSON_VALUE(_args, '$.token')              INTO _token;
+  SELECT JSON_VALUE(_args, '$.hub_id')             INTO _hub_id;
+  SELECT JSON_VALUE(_args, '$.node_id')            INTO _node_id;
+  SELECT JSON_VALUE(_args, '$.creator_id')         INTO _creator_id;
+  SELECT JSON_VALUE(_args, '$.recipient_email')    INTO _recipient_email;
+  SELECT JSON_VALUE(_args, '$.domain_restriction') INTO _domain_restriction;
+  SELECT JSON_VALUE(_args, '$.password_hash')      INTO _password_hash;
+  SELECT IFNULL(JSON_VALUE(_args, '$.expiry_hours'), 0) INTO _expiry_hours;
 
   IF _expiry_hours > 0 THEN
     SET _expiry_time = UNIX_TIMESTAMP() + (_expiry_hours * 3600);
@@ -24,8 +34,8 @@ BEGIN
   VALUES
     (_token, _hub_id, _node_id, _creator_id,
      LOWER(TRIM(_recipient_email)),
-     IF(TRIM(IFNULL(_domain_restriction, '')) = '', NULL, LOWER(TRIM(_domain_restriction))),
-     IF(TRIM(IFNULL(_password_hash, '')) = '', NULL, _password_hash),
+     NULLIF(LOWER(TRIM(IFNULL(_domain_restriction, ''))), ''),
+     NULLIF(TRIM(IFNULL(_password_hash, '')), ''),
      _expiry_time, UNIX_TIMESTAMP());
 
   SELECT


### PR DESCRIPTION
## Context

Follow-up to #19. @somanos requested during review that `secure_share_create` accept a single JSON argument instead of 8 positional parameters, following the pattern used by `mfs_create_node`.

## What changed

`secure_share_create` now accepts `IN _args JSON` and extracts each field with `JSON_VALUE`:

- Field order no longer matters
- Optional fields (`domain_restriction`, `password_hash`) resolve to `NULL` automatically when absent
- Future additions won't require changing the proc signature or any callers

**Only `yellow_page/procedures/secure_share/secure_share_create.sql` is touched** — no other procs, tables, or patches are affected.

## Deploy
Must be applied together with the matching server-team PR (drumee/server-team#34) so the proc and the caller stay in sync.

## Test plan
- [ ] `SHOW CREATE PROCEDURE secure_share_create` shows `IN _args JSON` (1 parameter)
- [ ] Create a secure share link (no password, with expiry) → link is generated correctly
- [ ] Create a secure share link with password → link generated, recipient password gate works
- [ ] Create a secure share link with domain restriction → domain stored correctly in DB