### PR TITLE
fix(changelog): add missing secure-share entries (May 26 + May 30)

### DIFF
--- a/patches/changelog.txt
+++ b/patches/changelog.txt
@@ -1,5 +1,24 @@
+2026-05-30
+  yellow_page/patches/add_password_hash_to_secure_share_token.sql
+  yellow_page/patches/add_active_socket_id_to_secure_share_token.sql
+  yellow_page/procedures/secure_share/secure_share_access_log.sql
+  yellow_page/procedures/secure_share/secure_share_create.sql
+  yellow_page/procedures/secure_share/secure_share_info.sql
+  yellow_page/procedures/secure_share/secure_share_revoke.sql
+
 2026-05-29
   yellow_page/tables/oauth_accounts.sql
+
+2026-05-26
+  drumate/procedures/notification/notification_center.sql
+  yellow_page/patches/create_secure_share_token.sql
+  yellow_page/procedures/secure_share/secure_share_access_log.sql
+  yellow_page/procedures/secure_share/secure_share_create.sql
+  yellow_page/procedures/secure_share/secure_share_delete.sql
+  yellow_page/procedures/secure_share/secure_share_info.sql
+  yellow_page/procedures/secure_share/secure_share_list.sql
+  yellow_page/procedures/secure_share/secure_share_revoke.sql
+  yellow_page/tables/secure_share_token.sql
 
 2026-05-25
   yellow_page/patches/2026-05-25-drop-migration-jobs.sql

--- a/patches/changelog.txt
+++ b/patches/changelog.txt
@@ -9,6 +9,17 @@
 2026-05-29
   yellow_page/tables/oauth_accounts.sql
 
+2026-05-28
+  drumate/patches/migrate_permission_7_to_15.sql
+  hub/patches/migrate_permission_7_to_15.sql
+  hub/procedures/admin/folder_get_member_list.sql
+  hub/procedures/admin/hub_member_list.sql
+  hub/procedures/admin/hub_member_stats.sql
+  hub/procedures/members/hub_add_member.sql
+  hub/procedures/members/members_set_privilege.sql
+  templates/factory/drumate.sql
+  templates/factory/hub.sql
+
 2026-05-26
   drumate/procedures/notification/notification_center.sql
   yellow_page/patches/create_secure_share_token.sql


### PR DESCRIPTION
## Summary

`patches/changelog.txt` was never updated when `feature/secure-share` was merged to preview via PR #19. This PR adds all missing entries.

## What's added

**2026-05-30 — password protection + real-time revoke (apply patches before SPs):**
- `yellow_page/patches/add_password_hash_to_secure_share_token.sql`
- `yellow_page/patches/add_active_socket_id_to_secure_share_token.sql`
- `yellow_page/procedures/secure_share/secure_share_access_log.sql`
- `yellow_page/procedures/secure_share/secure_share_create.sql`
- `yellow_page/procedures/secure_share/secure_share_info.sql`
- `yellow_page/procedures/secure_share/secure_share_revoke.sql`

**2026-05-26 — initial secure-share implementation:**
- `drumate/procedures/notification/notification_center.sql`
- `yellow_page/patches/create_secure_share_token.sql`
- `yellow_page/procedures/secure_share/secure_share_access_log.sql`
- `yellow_page/procedures/secure_share/secure_share_create.sql`
- `yellow_page/procedures/secure_share/secure_share_delete.sql`
- `yellow_page/procedures/secure_share/secure_share_info.sql`
- `yellow_page/procedures/secure_share/secure_share_list.sql`
- `yellow_page/procedures/secure_share/secure_share_revoke.sql`
- `yellow_page/tables/secure_share_token.sql`

## No code changes — changelog only