### PR TITLE
hotfix: add missing channel_read_messages procedure to drumate and hub

### DIFF
--- a/drumate/procedures/chat/channel_read_messages.sql
+++ b/drumate/procedures/chat/channel_read_messages.sql
@@ -1,0 +1,32 @@
+DELIMITER $
+
+DROP PROCEDURE IF EXISTS `channel_read_messages`$
+CREATE PROCEDURE `channel_read_messages`(
+  IN _msg_id VARCHAR(16),
+  IN _uid VARCHAR(16)
+)
+BEGIN
+  DECLARE _sys_id INTEGER DEFAULT 0;
+
+  SELECT sys_id FROM channel WHERE message_id = _msg_id INTO _sys_id;
+
+  UPDATE channel SET metadata = JSON_SET(metadata, CONCAT("$._seen_.", _uid), UNIX_TIMESTAMP())
+  WHERE sys_id <= _sys_id
+  AND JSON_EXISTS(metadata, CONCAT("$._seen_.", _uid)) = 0;
+
+  SELECT
+    sys_id,
+    author_id,
+    message,
+    message_id,
+    thread_id,
+    attachment,
+    status,
+    ctime,
+    metadata,
+    CASE WHEN JSON_EXISTS(metadata, CONCAT("$._seen_.", _uid)) = 1 THEN 1 ELSE 0 END is_readed,
+    CASE WHEN JSON_LENGTH(metadata, '$._seen_') = JSON_LENGTH(metadata, '$._delivered_') THEN 1 ELSE 0 END is_seen
+  FROM channel WHERE message_id = _msg_id;
+END$
+
+DELIMITER ;

--- a/hub/procedures/channel/channel_read_messages.sql
+++ b/hub/procedures/channel/channel_read_messages.sql
@@ -1,0 +1,32 @@
+DELIMITER $
+
+DROP PROCEDURE IF EXISTS `channel_read_messages`$
+CREATE PROCEDURE `channel_read_messages`(
+  IN _msg_id VARCHAR(16),
+  IN _uid VARCHAR(16)
+)
+BEGIN
+  DECLARE _sys_id INTEGER DEFAULT 0;
+
+  SELECT sys_id FROM channel WHERE message_id = _msg_id INTO _sys_id;
+
+  UPDATE channel SET metadata = JSON_SET(metadata, CONCAT("$._seen_.", _uid), UNIX_TIMESTAMP())
+  WHERE sys_id <= _sys_id
+  AND JSON_EXISTS(metadata, CONCAT("$._seen_.", _uid)) = 0;
+
+  SELECT
+    sys_id,
+    author_id,
+    message,
+    message_id,
+    thread_id,
+    attachment,
+    status,
+    ctime,
+    metadata,
+    CASE WHEN JSON_EXISTS(metadata, CONCAT("$._seen_.", _uid)) = 1 THEN 1 ELSE 0 END is_readed,
+    CASE WHEN JSON_LENGTH(metadata, '$._seen_') >= JSON_LENGTH(metadata, '$._delivered_') THEN 1 ELSE 0 END is_seen
+  FROM channel WHERE message_id = _msg_id;
+END$
+
+DELIMITER ;

--- a/patches/changelog.txt
+++ b/patches/changelog.txt
@@ -1,3 +1,6 @@
+2026-06-01
+  drumate/procedures/chat/channel_read_messages.sql
+
 2026-05-31
   common/procedures/mfs/mfs_set_poster.sql
 

--- a/patches/changelog.txt
+++ b/patches/changelog.txt
@@ -1,5 +1,6 @@
 2026-06-01
   drumate/procedures/chat/channel_read_messages.sql
+  hub/procedures/channel/channel_read_messages.sql
 
 2026-05-31
   common/procedures/mfs/mfs_set_poster.sql


### PR DESCRIPTION
## Summary

- `channel_read_messages` stored procedure exists in the drumate template but was never patched to existing databases
- Causing `ER_SP_DOES_NOT_EXIST` errors in production and UAT since 2026-06-01
- Affects all per-user drumate DBs (P2P chat read receipts broken)

## Deploy order

Apply the patch **before** merging (no server restart needed):

```bash
bin/patch-from-file drumate/procedures/chat/channel_read_messages.sql drumate
```

## Test plan

- [ ] Apply patch on stage, confirm no more `channel_read_messages does not exist` errors in logs
- [ ] Open a P2P chat, read messages — no backend error
- [ ] Confirm alerts stop firing on UAT and PROD after patch applied