### PR TITLE
feat(oauth-2fa): gate session_login_with_oauth on email-2FA flag

### DIFF
--- a/docs/superpowers/plans/2026-06-18-oauth-2fa.md
+++ b/docs/superpowers/plans/2026-06-18-oauth-2fa.md
@@ -1,0 +1,103 @@
+# OAuth 2FA Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When a user with email-2FA enabled (`profile.otp === 'email'`) signs in via Google or Apple, require the same email OTP — reusing the existing `dtk_otp` widget and the provider-agnostic `session_login_otp` verify proc.
+
+**Architecture:** The OAuth callback (loby) detects the user's 2FA flag, leaves the session in an `otp_pending` cookie status instead of `ok`, emails an OTP, and redirects the browser back to the signin SPA with an `oauth_mfa` marker. The SPA renders `dtk_otp` against a new `oauth.verify_otp` service that reads the OTP secret server-side, calls `session_login_otp`, and promotes the cookie to `ok`. The secret never leaves the server.
+
+**Tech Stack:** MariaDB stored procedures (schemas), Node @drumee microservice (loby), LetcBox JS widgets (signin SPA).
+
+## Global Constraints
+
+- One routine per `.sql` file; always `DROP ... IF EXISTS` before `CREATE`; params/vars prefixed `_`.
+- Schema changes are not live until patched: `bin/patch-from-file <file> yellow_page` then sweep all YP instances.
+- 2FA method is **email only**. New OAuth signups (`otp:0`) are never challenged.
+- Each repo gets its own branch `feat/oauth-2fa` and its own commit(s).
+- Co-author trailer on commits: `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+
+---
+
+### Task 1: Gate `session_login_with_oauth` on the 2FA flag (schemas)
+
+**Files:**
+- Modify: `yellow_page/procedures/session/session_login_with_oauth.sql`
+
+**Interfaces:**
+- Produces: when the resolved user has `JSON_VALUE(profile,'$.otp')='email'`, the proc sets `cookie.status='otp_pending'` and returns a single row `{ failed, status, error_code:'otp_required', id:<uid>, email }`. Otherwise behavior is unchanged (`ok` session row, or `oauth_user_not_found` / `oauth_not_linked`).
+
+- [ ] **Step 1:** In the `ELSE` branch (user found, after `_sid` is resolved/created), before the final `ok` UPDATE+SELECT, add a guard: if `JSON_VALUE(_profile,'$.otp') = 'email'`, then `UPDATE cookie SET failed=0, mtime=UNIX_TIMESTAMP(), uid=_uid, status='otp_pending' WHERE id=_cid;` and `SELECT 0 AS failed, 'otp_pending' AS status, 'otp_required' AS error_code, _uid AS id, _email AS email;` then `LEAVE sp_main;`. Leave the existing `ok` path untouched for non-2FA users.
+- [ ] **Step 2:** Apply to local YP: `bin/patch-from-file yellow_page/procedures/session/session_login_with_oauth.sql yellow_page`. Expected: applies without error.
+- [ ] **Step 3:** Manually verify both paths with a test user (toggle `profile.otp`): a non-2FA user returns `status='ok'` with the full session row; a 2FA user returns `error_code='otp_required'`.
+- [ ] **Step 4:** Commit on branch `feat/oauth-2fa`.
+
+---
+
+### Task 2: loby callback — mint+email OTP and redirect to the SPA (loby)
+
+**Files:**
+- Modify: `service/lib/loby.js` (`handleOAuthCallback`; add `_send2faOtp(uid, email)` helper)
+- Modify: `service/google.js` (`callback`)
+- Modify: `service/apple.js` (`callback`)
+- Create: `service/templates/otp-challenge.html` (redirect-to-SPA page)
+- Reuse: `service/templates/otp.html` (existing email template; vars `heading`,`code`,`why_this_otp`)
+
+**Interfaces:**
+- Consumes: Task 1's `error_code:'otp_required'` from `session_login_with_oauth`; `otp_create(uid, token)` → row `{ code, secret }`.
+- Produces: `handleOAuthCallback` returns `{ status:'otp_required', email, id, provider }` when 2FA is required.
+
+- [ ] **Step 1:** In `handleOAuthCallback`, after the CASE A/B/C branches, add: if `sessionData.error_code === 'otp_required'`, call `await this._send2faOtp(sessionData.id, sessionData.email)`, then `return { status:'otp_required', email: sessionData.email, id: sessionData.id, provider }`.
+- [ ] **Step 2:** Add helper `_send2faOtp(uid, email)`: `const token = uniqueId(); const otp = await this.yp.await_proc('otp_create', uid, token);` render `./templates/otp.html` with `{ heading: lex._your_otp, code: otp.code, why_this_otp: lex._why_this_otp }` via `Messenger` (recipient `email`, From `"Drumee" <butler>` when sender configured — mirror `service/signup.js` send pattern), send. Pull `lex` via `Cache.lex(this.input.ua_language() || 'en')`. Imports: `Messenger`, `uniqueId` from `@drumee/server-essentials`; `Cache`.
+- [ ] **Step 3:** Create `service/templates/otp-challenge.html`: a minimal page whose only behavior is `<script>location.replace('<%= redirect %>')</script>` (lodash `template` style, matching `account-created.html`).
+- [ ] **Step 4:** In `service/google.js` `callback()`: after `handleOAuthCallback`, if `res.status === 'otp_required'`, build `redirect = https://${main_domain}${endpoint_path}/#/welcome/signin?oauth_mfa=1&email=${encodeURIComponent(res.email)}` and `this.sendHtml({ ...res, redirect, session_id: this.input.sid() }, resolve(__dirname,'./templates/otp-challenge.html'))` (so the browser keeps the pending session cookie), and `return`. Otherwise existing behavior.
+- [ ] **Step 5:** Mirror Step 4 in `service/apple.js` `callback()`.
+- [ ] **Step 6:** Commit on branch `feat/oauth-2fa`.
+
+---
+
+### Task 3: loby `oauth.verify_otp` / `oauth.resend_otp` services (loby)
+
+**Files:**
+- Create: `service/oauth.js`
+- Create: `acl/oauth.json`
+
+**Interfaces:**
+- Consumes: pending cookie (`status='otp_pending'`, `uid` set) keyed by `this.input.sid()`; the latest `otp` row's `secret` for that uid; `session_login_otp(key, code, secret, cid)` → `{ status:'success'|'error' }`.
+- Produces: `SERVICE.oauth.verify_otp({code})` → `{status:'success'}` (cookie promoted to `ok`) or `{status:'error'}`; `SERVICE.oauth.resend_otp()` → `{status:'ok'}`.
+
+- [ ] **Step 1:** Create `acl/oauth.json` mirroring `acl/google.json` shape with services `verify_otp` and `resend_otp` (`scope:"hub"`, `permission:{src:"anonymous", fast_check:"public-api"}`) and `modules.{private,public}: "service/oauth"`.
+- [ ] **Step 2:** Create `service/oauth.js extends Loby`. `verify_otp()`: `const sid=this.input.sid(); const code=this.input.get(Attr.code);` resolve `{uid} = await this.yp.await_query("SELECT uid FROM cookie WHERE id=? AND status='otp_pending'", sid)`; if no uid → `return this.output.data({status:'error'})`; `const {secret} = await this.yp.await_query("SELECT secret FROM otp WHERE uid=? ORDER BY sys_id DESC LIMIT 1", uid)`; `let r = toArray(await this.yp.await_proc('session_login_otp', uid, code, secret, sid))[0]; this.output.data(r || {status:'error'})`.
+- [ ] **Step 3:** `resend_otp()`: resolve `{uid,email}` for the pending cookie (`SELECT c.uid, d.email FROM cookie c JOIN drumate d ON d.id=c.uid WHERE c.id=? AND c.status='otp_pending'`); if none → `{status:'error'}`; else `await this._send2faOtp(uid, email); this.output.data({status:'ok'})`.
+- [ ] **Step 4:** Manually verify: with a pending cookie + known otp row, `verify_otp` with the right code returns `{status:'success'}` and flips cookie to `ok`; wrong code returns `{status:'error'}`.
+- [ ] **Step 5:** Commit on branch `feat/oauth-2fa`.
+
+---
+
+### Task 4: signin SPA — detect `oauth_mfa` and render `dtk_otp` (signin)
+
+**Files:**
+- Modify: `src/widgets/router/index.js` (`onDomRefresh`; reuse `_resendSigninOtp` via `resendApi`)
+
+**Interfaces:**
+- Consumes: URL hash `#/welcome/signin?oauth_mfa=1&email=...`; `SERVICE.oauth.verify_otp`, `SERVICE.oauth.resend_otp`; existing handlers `otp-signined` (reload) and `resend-signin-otp`.
+
+- [ ] **Step 1:** Add a private `_oauthMfaParams()` that parses `location.hash` for `oauth_mfa=1` and returns `{ email }` (decoded) or null. (Query string lives inside the hash fragment.)
+- [ ] **Step 2:** In `onDomRefresh()`, before the `connection == 'otp'` check, add: `const mfa = this._oauthMfaParams(); if (mfa) { await Kind.waitFor('dtk_otp'); this.feed({ payload: { email: mfa.email, method: 'oauth' }, kind:'dtk_otp', api: SERVICE.oauth.verify_otp, resendApi: SERVICE.oauth.resend_otp, title: "Multi factor authentication", message: "We have sent a code to {0} to validate your connection".format(mfa.email), resendService: 'resend-signin-otp', service: 'otp-signined' }); this._otp = this.children.last(); return; }`.
+- [ ] **Step 3:** Confirm `_resendSigninOtp` already honors `otp.mget('resendApi')` (it does) so resend posts to `SERVICE.oauth.resend_otp`. No change needed beyond setting `resendApi`.
+- [ ] **Step 4:** Build the SPA (`webpack.js`) to confirm no syntax/reference errors.
+- [ ] **Step 5:** Commit on branch `feat/oauth-2fa`.
+
+---
+
+### Task 5: End-to-end verification
+
+- [ ] **Step 1:** With a test account that has `profile.otp='email'`, sign in via Google: confirm the provider round-trip lands on the SPA OTP screen, the code email arrives, entering it signs in (reload → desk), and a wrong code shows the inline error.
+- [ ] **Step 2:** Confirm a non-2FA account still signs in via Google with no OTP prompt (regression).
+- [ ] **Step 3:** Repeat Step 1 for Apple.
+- [ ] **Step 4:** Confirm resend re-sends the code for the pending session.
+
+## Self-Review
+
+- **Spec coverage:** Trigger gate (Task 1), OTP email + handoff (Task 2), server-side verify keeping secret server-side (Task 3), SPA reuse of dtk_otp (Task 4), e2e (Task 5). `server-team` needs no change (loby has `otp.html` + `Messenger`); the spec's "duplicate template" open question resolves to "reuse loby's existing template."
+- **Type consistency:** `error_code:'otp_required'` (Task 1) → consumed Task 2; `{status:'otp_required',email,id}` (Task 2) → consumed Task 4 marker; `session_login_otp` `{status:'success'|'error'}` matches `dtk_otp._isErrorResponse` (success passes, error/wrong-code rejected).
+- **Placeholders:** none.

--- a/docs/superpowers/specs/2026-06-18-oauth-2fa-design.md
+++ b/docs/superpowers/specs/2026-06-18-oauth-2fa-design.md
@@ -1,0 +1,157 @@
+# Design: 2FA for OAuth (Google / Apple) login
+
+Date: 2026-06-18
+Status: Approved pending review
+
+## Goal
+
+When a user who has **email-2FA enabled** (`profile.otp === 'email'`) signs in via
+"Sign in with Google" or "Sign in with Apple", require the same email OTP that a
+password login already requires. The challenge reuses the existing `dtk_otp`
+widget and the provider-agnostic `session_login_otp` verification path. Brand-new
+OAuth sign-ups (created with `otp: 0`) are never challenged.
+
+### Decisions (confirmed with user)
+
+1. **Trigger:** Reuse the existing per-user 2FA flag (`profile.otp === 'email'` /
+   `mfa`). No new OAuth-only setting; no always-on forcing.
+2. **OTP UI:** Reuse the signin SPA's `dtk_otp` widget. The loby callback redirects
+   the browser back to the signin app in a pending state.
+3. **Method:** Email OTP only (matches the working `_send2faOtpEmail` path).
+   SMS/passkey are out of scope.
+
+## Background — the two existing flows
+
+### Password 2FA (works today)
+- `yp.login` -> `session.signin(vars)`. A `session.send_otp` override checks
+  `profile.otp === 'email'` and calls `_send2faOtpEmail(user)`
+  (`server-team/service/yp.js`), which mints an OTP via `otp_create(uid, token)`,
+  emails the code using `service/templates/otp.html`, and returns `{ secret }`.
+- The signin response carries `secret` (no full session). The SPA renders
+  `dtk_otp` and submits `{ uid, code, secret }` to `yp.login_top`
+  (`signin/src/widgets/router/index.js`, the `verify-signin-otp` handler).
+- `yp.login_top` -> `session_login_otp(uid, code, secret, sid)`
+  (`yellow_page/procedures/session/session_login_otp.sql`) verifies the code
+  against the `otp` table and promotes `cookie.status` to `ok`.
+
+### OAuth (no 2FA today)
+- SPA -> `google.initiate` / `apple.initiate`
+  (`loby/service/google.js`, `apple.js`) returns `{ status:'prompt', authUrl }`
+  and stores an `oauth_state` row keyed to the signin session id.
+- `location.href = authUrl` -> provider -> loby `*.callback`.
+- `callback()` -> `handleOAuthCallback(profile)` (`loby/service/lib/loby.js`).
+- `session_login_with_oauth(provider, provider_id, email, session_id, domain)`
+  (`yellow_page/procedures/session/session_login_with_oauth.sql`) finds/links the
+  user and **unconditionally** sets `cookie.status='ok'`, returning the full
+  session.
+- `callback()` -> `sendHtml(...)` sets the authorized session cookie
+  (`setAuthorization`) and returns an HTML page that redirects to the desk.
+
+## Key insight
+
+`session_login_otp(key, code, secret, cid)` finalizes **whatever pending cookie**
+matches a valid OTP — it is agnostic to how the session was started. So adding
+2FA to OAuth requires only:
+
+1. Leave the OAuth session **pending** instead of `ok` when 2FA is required.
+2. Mint an OTP row and email the code.
+3. Hand off to the SPA's `dtk_otp` widget, which finalizes the pending cookie.
+
+The OTP secret never needs to leave the server (an improvement over the password
+flow, which returns the secret to client JS).
+
+## Target flow (existing user with email-2FA, via Google/Apple)
+
+1. SPA -> `google/apple.initiate` -> redirect to provider. *(unchanged)*
+2. Provider -> loby `*.callback` -> `handleOAuthCallback()`.
+3. `session_login_with_oauth` resolves the user, sees
+   `JSON_VALUE(profile,'$.otp') = 'email'`, sets `cookie.status='otp_pending'`
+   (NOT `ok`), and returns `error_code = 'otp_required'` plus `id` and `email`.
+4. loby, on `otp_required`:
+   - `otp_create(uid, token)` -> `{ code, secret }`.
+   - Emails the code (same `otp.html` template + `Messenger` as
+     `_send2faOtpEmail`; display-name From `"Drumee" <butler@...>`).
+   - Returns an HTML page that **redirects the browser to the signin SPA** in a
+     pending state, e.g. `https://{domain}/#/welcome/signin?oauth_mfa=1&email=...`.
+   - Does **not** call `sendHtml` / `setAuthorization` — the session stays
+     pending. The secret stays server-side.
+5. SPA detects `oauth_mfa=1` on load -> renders `dtk_otp` -> user enters the
+   6-digit code -> calls `oauth.verify_otp` with `{ code }` (no client secret).
+6. `oauth.verify_otp` resolves the pending cookie from `input.sid()`, reads the
+   server-side secret for that uid, calls
+   `session_login_otp(uid, code, secret, sid)`. On success: `cookie.status='ok'`,
+   `setAuthorization`, return session -> SPA reloads -> signed in.
+7. Resend -> `oauth.resend_otp` regenerates + re-emails for the pending session.
+
+## Changes by repo
+
+### schemas (this repo) — requires DB patching across all YP instances
+- `yellow_page/procedures/session/session_login_with_oauth.sql`
+  - After STEP 3 resolves `_profile`, before the final `ok` select, branch on
+    `JSON_VALUE(_profile,'$.otp') = 'email'`:
+    - Set `cookie.status = 'otp_pending'` (do NOT set `ok`).
+    - Return a result row carrying `error_code = 'otp_required'`, plus `id`
+      (uid) and `email`, so loby can mint/email the OTP.
+  - The `oauth_user_not_found` (new user) and `oauth_not_linked` branches are
+    unchanged. Auto-linked existing accounts with 2FA are covered automatically
+    because the branch keys off the resolved profile.
+- Patch via `bin/patch-from-file yellow_page/procedures/session/session_login_with_oauth.sql yellow_page`,
+  then sweep all YP instances. (Schema change != live until patched.)
+
+### loby
+- `service/lib/loby.js`
+  - `handleOAuthCallback`: handle the new `otp_required` result — mint OTP
+    (`otp_create`), email it, and return a marker `{ status:'otp_required',
+    email, id, provider }`.
+  - Add a `sendOtpEmail(user)` helper (port of `_send2faOtpEmail`).
+- `service/google.js` + `service/apple.js`
+  - `callback()`: when `handleOAuthCallback` returns `otp_required`, redirect the
+    browser to the signin SPA pending route instead of `sendHtml`.
+- New `service/oauth.js` + `acl/oauth.json` (provider-agnostic; keyed off the
+  pending session):
+  - `verify_otp({ code })`: resolve pending cookie uid from `input.sid()`, read
+    secret, call `session_login_otp`, set authorization on success, return
+    session.
+  - `resend_otp()`: re-mint + re-email for the pending session.
+- `service/templates/otp.html`: copy of the server-team template (or a shared
+  template). See open question below.
+
+### signin SPA (`src/widgets/form` + `src/widgets/router`)
+- `src/widgets/form/index.js`: on load (`initialize`/`onDomRefresh`), detect the
+  `oauth_mfa=1` (+ `email`) marker and drive the existing `verify-signin-otp`
+  path, but pointed at `SERVICE.oauth.verify_otp` with an OAuth payload
+  (no client-side secret).
+- `src/widgets/router/index.js`: extend the `verify-signin-otp` handler to accept
+  an api/method override so it can target `SERVICE.oauth.verify_otp`; wire the
+  resend action to `SERVICE.oauth.resend_otp`.
+- `SERVICE.oauth.*` resolves from the platform services (same mechanism as
+  `SERVICE.google.*` / `SERVICE.apple.*`).
+
+## Security / edge cases
+
+- OTP secret never leaves the server (stronger than the password flow).
+- OTP rows self-expire after 10 minutes (`session_login_otp` deletes stale rows).
+- Abandoned challenge -> pending cookie never promoted to `ok`; harmless and
+  expires.
+- Brand-new OAuth signups (`otp: 0`) are not challenged.
+- Existing password accounts auto-linked to a provider on first OAuth use are
+  still challenged (branch keys off the resolved profile).
+- Pending cookie binding: `oauth_state.session_id` == the signin session ==
+  `input.sid()` after the redirect, because the pending HTML does NOT overwrite
+  the session authorization. The SPA verify call therefore resolves the correct
+  pending cookie. **Verify during implementation** that the signin session cookie
+  survives the provider round-trip.
+
+## Open implementation choice (non-blocking)
+
+The 2FA email send in loby can either (a) **duplicate** the `otp.html` template +
+Messenger logic from server-team, or (b) call a small shared private service.
+Default: **(a) duplicate the template into loby**, matching how loby already
+replicates account-creation logic. Flag for revisit if a shared template is
+preferred.
+
+## Out of scope
+
+- SMS and passkey 2FA methods.
+- Changing the per-user 2FA enable/disable admin UI (already exists).
+- Drive-migration OAuth token handling (untouched).

--- a/yellow_page/procedures/session/session_login_with_oauth.sql
+++ b/yellow_page/procedures/session/session_login_with_oauth.sql
@@ -87,14 +87,37 @@ sp_main: BEGIN
     ELSE
       -- User found - Create/update session
       SELECT id FROM cookie WHERE id = _cid INTO _sid;
-      IF _sid IS NULL THEN 
+      IF _sid IS NULL THEN
         SELECT _cid INTO _sid;
         SELECT UNIX_TIMESTAMP() INTO _ctime;
         INSERT INTO cookie (`id`,`uid`,`ctime`,`mtime`,`ua`, `status`)
         VALUES(_sid, _uid, _ctime, _ctime, 'oauth_login', 'new');
       END IF;
-      
-      
+
+      -- 2FA gate: when the resolved user has email-based 2FA enabled, do NOT
+      -- finalize the session here. Leave the cookie in an 'otp_pending' state
+      -- and return an 'otp_required' marker so the caller (loby) can mint+email
+      -- an OTP and hand off to the signin app's OTP screen, which finalizes the
+      -- same pending cookie via session_login_otp. Mirrors the password-login
+      -- 2FA path (profile.otp === 'email').
+      IF JSON_VALUE(_profile, '$.otp') = 'email' THEN
+        UPDATE cookie SET
+          failed = 0,
+          mtime = UNIX_TIMESTAMP(),
+          `uid` = _uid,
+          status = 'otp_pending'
+        WHERE id = _cid;
+
+        SELECT
+          0 AS failed,
+          'otp_pending' AS `status`,
+          'otp_required' AS error_code,
+          _uid AS id,
+          _email AS email;
+        LEAVE sp_main;
+      END IF;
+
+
       UPDATE cookie SET 
         failed = 0, 
         mtime = UNIX_TIMESTAMP(), 


### PR DESCRIPTION
When the resolved OAuth user has profile.otp === 'email', leave the cookie in an 'otp_pending' status and return an 'otp_required' marker instead of finalizing the session. The signin app's OTP screen then finalizes the same pending cookie via session_login_otp — mirroring the password-login 2FA path.

Includes the design spec and implementation plan.