### PR TITLE
session: clear_session_priv_ceiling SP (clear A3 ceiling on unclamp)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drumee/schemas",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "description": "Drumee schemas",
   "main": "bin/patch.js",
   "repository": {

--- a/patches/changelog.txt
+++ b/patches/changelog.txt
@@ -1,3 +1,6 @@
+2026-06-22
+  yellow_page/procedures/session/clear_session_priv_ceiling.sql
+
 2026-06-19
   common/procedures/mfs/mfs_node_in_subtree.sql
 

--- a/yellow_page/procedures/session/clear_session_priv_ceiling.sql
+++ b/yellow_page/procedures/session/clear_session_priv_ceiling.sql
@@ -1,0 +1,11 @@
+DELIMITER $
+
+DROP PROCEDURE IF EXISTS `clear_session_priv_ceiling`$
+CREATE PROCEDURE `clear_session_priv_ceiling`(
+  IN _sid VARCHAR(64)
+)
+BEGIN
+  UPDATE cookie SET priv_ceiling=NULL, ceiling_uid=NULL WHERE id=_sid;
+END$
+
+DELIMITER ;


### PR DESCRIPTION
Adds **`yellow_page/procedures/session/clear_session_priv_ceiling.sql`** (yp) + changelog (v1.1.11).

## Why
Companion to the secure-share recipient fix (Codex P2 on server-team#66). v2.9.71 made the A3 ceiling stamp **conditional** to avoid `ER_TRUNCATED` (the mariadb driver serialises JS `null`→`''` into the `set_session_priv_ceiling` TINYINT), but that means a **stale ceiling is never cleared**: when the same share-session sid is reused by the same uid after an access upgrade (view/chat→edit, or →member/owner), `get_session_priv_ceiling` keeps returning the old value (it only self-clears on a uid change), so router/rest keeps denying the newly-granted writes with `SECURE_SHARE_READ_ONLY`.

This SP sets `priv_ceiling`/`ceiling_uid` = `NULL` directly in SQL (no null param → no ER_TRUNCATED), so `dmz.js` can **clear** the ceiling on an unclamped login instead of skipping. server-team uses it via `clear_session_priv_ceiling(sid)`.

## Apply
- yp class (single DB). **Already applied + verified on the drumee.in stage yp** (`bin/patch-from-file … yp`; no factory restart — yp isn't in the factory dump).
- Liam applies to the preview/prod yp DB at deploy (via the changelog entry).
