### PR TITLE
feat: per-folder team-chat notifications + chat reactions (port from server-team stage)

### DIFF
--- a/drumate/procedures/chat/p2p_message_reaction_toggle.sql
+++ b/drumate/procedures/chat/p2p_message_reaction_toggle.sql
@@ -1,0 +1,109 @@
+-- File: schemas/drumate/procedures/chat/p2p_message_reaction_toggle.sql
+-- =========================================================
+-- p2p_message_reaction_toggle  (DRUMATE class — inbox DM / P2P)
+-- One reaction per user per message (same rule as message_reaction_toggle).
+-- P2P messages are single-write in the AUTHOR's drumate DB, so chat.react runs
+-- this locally for own messages and via forward_proc(peer_id, ...) for
+-- peer-authored ones — this SP always acts on the row in whichever DB it runs.
+--
+-- All writes operate DIRECTLY on `_meta` via JSON_REMOVE / JSON_ARRAY_APPEND /
+-- JSON_SET(..., JSON_ARRAY()) — never JSON_SET a string variable as the value
+-- (that double-encodes the sub-object). Preserves `_seen_`. Requires MariaDB
+-- 10.2.3+. Caller validates emoji; uids are 16-char ascii hex.
+--
+-- Target table `p2p_channel` (verified present with a metadata column on stage).
+--
+-- Returns one row: found (0 if message absent -> caller tries the peer DB via
+-- forward_proc), capped (1 if a new emoji hit the cap), reactions (the map).
+--
+-- Apply (DEV/STAGE ONLY — every drumate instance on the server):
+--   bin/patch-from-file patches/p2p-message-reaction-toggle.sql drumate
+-- =========================================================
+DELIMITER $
+
+DROP PROCEDURE IF EXISTS `p2p_message_reaction_toggle`$
+CREATE PROCEDURE `p2p_message_reaction_toggle`(
+  IN _message_id VARCHAR(16) CHARACTER SET ascii,
+  IN _uid VARCHAR(16) CHARACTER SET ascii,
+  IN _emoji VARCHAR(64) CHARACTER SET utf8mb4
+)
+BEGIN
+  DECLARE _meta LONGTEXT;
+  DECLARE _keys LONGTEXT;
+  DECLARE _arr LONGTEXT;
+  DECLARE _key VARCHAR(64) CHARACTER SET utf8mb4;
+  DECLARE _kpath VARCHAR(160);
+  DECLARE _epath VARCHAR(160);
+  DECLARE _hit VARCHAR(64);
+  DECLARE _n INT DEFAULT 0;
+  DECLARE _k INT DEFAULT 0;
+  DECLARE _was_mine INT DEFAULT 0;
+  DECLARE _capped INT DEFAULT 0;
+  DECLARE _exists INT DEFAULT 0;
+  DECLARE EXIT HANDLER FOR SQLEXCEPTION
+  BEGIN
+    ROLLBACK;
+    RESIGNAL;
+  END;
+
+  SET _epath = CONCAT('$._reactions_."', _emoji, '"');
+
+  START TRANSACTION;
+  SELECT COUNT(1) INTO _exists FROM `p2p_channel` WHERE message_id = _message_id;
+
+  IF _exists = 0 THEN
+    COMMIT;
+    SELECT 0 AS found, 0 AS capped, JSON_OBJECT() AS reactions;
+  ELSE
+    SELECT metadata INTO _meta FROM `p2p_channel` WHERE message_id = _message_id FOR UPDATE;
+    SET _meta = COALESCE(NULLIF(_meta, ''), '{}');
+    IF JSON_EXTRACT(_meta, '$._reactions_') IS NULL THEN
+      SET _meta = JSON_SET(_meta, '$._reactions_', JSON_OBJECT());
+    END IF;
+
+    SET _keys = COALESCE(JSON_KEYS(JSON_EXTRACT(_meta, '$._reactions_')), JSON_ARRAY());
+    SET _n = JSON_LENGTH(_keys);
+    SET _k = 0;
+    WHILE _k < _n DO
+      SET _key = JSON_UNQUOTE(JSON_EXTRACT(_keys, CONCAT('$[', _k, ']')));
+      SET _kpath = CONCAT('$._reactions_."', _key, '"');
+      SET _arr = JSON_EXTRACT(_meta, _kpath);
+      IF _arr IS NOT NULL AND JSON_CONTAINS(_arr, JSON_QUOTE(_uid)) THEN
+        -- Compare emojis with BINARY collation. The connection's default
+        -- utf8mb4_general_ci treats DISTINCT emojis as EQUAL ('👍' = '😮' is
+        -- TRUE), which made a switch (react 👍, then pick 😮) look like a
+        -- toggle-off: _was_mine was set, the old emoji was removed, and the new
+        -- one was NEVER added until a second call. utf8mb4_bin keeps same-emoji
+        -- equal (toggle-off still works) while distinguishing different emojis.
+        IF _key = _emoji COLLATE utf8mb4_bin THEN SET _was_mine = 1; END IF;
+        SET _hit = JSON_UNQUOTE(JSON_SEARCH(_arr, 'one', _uid));
+        IF _hit IS NOT NULL THEN
+          SET _meta = JSON_REMOVE(_meta, CONCAT(_kpath, SUBSTR(_hit, 2)));
+        END IF;
+        IF JSON_LENGTH(JSON_EXTRACT(_meta, _kpath)) = 0 THEN
+          SET _meta = JSON_REMOVE(_meta, _kpath);
+        END IF;
+      END IF;
+      SET _k = _k + 1;
+    END WHILE;
+
+    IF _was_mine = 0 THEN
+      IF JSON_EXTRACT(_meta, _epath) IS NULL THEN
+        IF JSON_LENGTH(JSON_EXTRACT(_meta, '$._reactions_')) < 50 THEN
+          SET _meta = JSON_SET(_meta, _epath, JSON_ARRAY(_uid));
+        ELSE
+          SET _capped = 1;
+        END IF;
+      ELSE
+        SET _meta = JSON_ARRAY_APPEND(_meta, _epath, _uid);
+      END IF;
+    END IF;
+
+    UPDATE `p2p_channel` SET metadata = _meta WHERE message_id = _message_id;
+    COMMIT;
+    SELECT 1 AS found, _capped AS capped,
+           COALESCE(JSON_EXTRACT(_meta, '$._reactions_'), JSON_OBJECT()) AS reactions;
+  END IF;
+END $
+
+DELIMITER ;

--- a/drumate/procedures/notification/notification_center_next.sql
+++ b/drumate/procedures/notification/notification_center_next.sql
@@ -1,0 +1,194 @@
+-- File: schemas/drumate/procedures/notification/notification_center_next.sql
+DELIMITER $
+
+DROP PROCEDURE IF EXISTS `notification_center_next`$
+CREATE PROCEDURE `notification_center_next`()
+BEGIN
+
+DECLARE _uid VARCHAR(16) CHARACTER SET ascii;
+DECLARE _db_name VARCHAR(500);
+DECLARE _nid VARCHAR(16) CHARACTER SET ascii;
+DECLARE _domain_id INT;
+DECLARE _is_support INT DEFAULT 0 ;
+DECLARE _area VARCHAR(500);
+DECLARE _wicket_db_name VARCHAR(255);
+DECLARE _wicket_id VARCHAR(16);
+
+  SELECT id FROM yp.entity WHERE db_name = DATABASE() INTO _uid;
+
+  DROP TABLE IF EXISTS _show_node;
+  CREATE TEMPORARY TABLE _show_node (
+      resource_id  VARCHAR(16) CHARACTER SET ascii,
+      entity_id VARCHAR(16) CHARACTER SET ascii,
+      hub_id VARCHAR(16) CHARACTER SET ascii,
+      nid VARCHAR(16) CHARACTER SET ascii,
+      parent_id VARCHAR(16) CHARACTER SET ascii,
+      filename VARCHAR(128),
+      filetype VARCHAR(16),
+      item_filetype VARCHAR(16),
+      last_id INT(11) UNSIGNED,
+      ctime  INT(11) ,
+      area  VARCHAR(16),
+      category VARCHAR(16)
+
+   );
+
+
+   INSERT INTO _show_node
+   SELECT
+      ci.id  ,d.id ,_uid , NULL, NULL, NULL, NULL, NULL, NULL, mtime,'personal' ,'contact'
+   FROM
+   contact ci
+   INNER JOIN yp.drumate d ON d.id = ci.entity
+   WHERE (ci.status="received") OR (ci.status="informed") OR (ci.status="invitation");
+
+
+   INSERT INTO _show_node
+   SELECT
+      ch.message_id, ch.author_id , _uid , NULL, NULL, NULL, NULL, NULL, NULL, ch.ctime , 'personal' , 'chat'
+   FROM
+      channel ch
+   INNER JOIN read_channel rc ON ch.entity_id= rc.entity_id
+   INNER JOIN contact c ON c.uid = ch.entity_id
+   WHERE ch.entity_id = ch.author_id  AND  rc.entity_id <> rc.uid  AND  ch.sys_id > rc.ref_sys_id;
+
+
+   DROP TABLE IF EXISTS _my_hubs;
+   CREATE TEMPORARY TABLE _my_hubs  AS
+   SELECT m.sys_id , he.id , db_name , he.area
+   FROM
+   media m
+   INNER JOIN yp.entity he ON m.id = he.id
+   INNER JOIN yp.hub h ON m.id = h.id
+   WHERE category = 'hub' AND extension <> 'dmz'  AND m.status <> 'hidden' ;
+
+   ALTER TABLE _my_hubs ADD `is_checked` boolean default 0 ;
+
+   SELECT id, db_name,area FROM _my_hubs WHERE is_checked =0  LIMIT 1
+   INTO _nid, _db_name,_area;
+
+   WHILE _nid IS NOT NULL DO
+
+      -- Per-folder team-chat rollup. nid = the folder a message was posted in
+      -- (channel.metadata._scope_nid; NULL for hub-level/legacy chat → groups as
+      -- one hub-level row). filename/parent come from that folder's media node so
+      -- the activity item shows the folder name and opens it. Unread is per-message
+      -- (delivered AND not _seen_), matching channel_list_notifications, so reading
+      -- one folder's messages does not clear a sibling folder's mentions.
+      SET @sql=  CONCAT(
+         "INSERT INTO _show_node
+         SELECT c.message_id,'", _nid ,"','",_nid, "' As hub_id , JSON_UNQUOTE(JSON_EXTRACT(c.metadata,'$._scope_nid')), sf.parent_id, sf.user_filename, 'folder', NULL, c.sys_id, c.ctime,'", _area, "','teamchat'  FROM ", _db_name ,".channel c LEFT JOIN ", _db_name ,".media sf ON sf.id = JSON_UNQUOTE(JSON_EXTRACT(c.metadata,'$._scope_nid')) WHERE c.status='active' AND c.author_id <> '", _uid ,"' AND JSON_EXISTS(c.metadata,'$._delivered_.", _uid ,"')=1 AND JSON_EXISTS(c.metadata,'$._seen_.", _uid ,"')=0" ) ;
+      EXECUTE IMMEDIATE @sql;
+
+      SET @s = CONCAT(
+          " INSERT INTO _show_node
+            SELECT m.id, m.owner_id, '" , _nid , "', target.id, target.parent_id, target.user_filename, 'folder', m.category, m.sys_id, m.upload_time,'", _area ,"','media' FROM ", _db_name ,
+          ".media m LEFT JOIN ", _db_name ,".media target ON target.id = IF(m.category = 'folder', m.id, m.parent_id) WHERE m.file_path not REGEXP '^/__(chat|trash)__'  AND m.category != 'root' AND
+            IFNULL((is_new(m.metadata, m.owner_id, ?)), 0) =1 "
+        );
+      PREPARE stmt FROM @s;
+      EXECUTE stmt USING _uid;
+      DEALLOCATE PREPARE stmt;
+
+      UPDATE _my_hubs SET is_checked = 1 WHERE id = _nid ;
+      SELECT  NULL INTO  _nid;
+      SELECT id, db_name,area FROM _my_hubs WHERE is_checked =0  LIMIT 1 INTO _nid, _db_name,_area;
+   END WHILE;
+
+
+
+   SELECT domain_id FROM yp.privilege WHERE uid = _uid INTO _domain_id;
+   SELECT 1  FROM yp.sys_conf WHERE  conf_key = 'support_domain'
+   AND conf_value =_domain_id INTO _is_support;
+
+
+   IF _is_support <> 1 THEN
+
+      SELECT h.id FROM
+      yp.hub h INNER JOIN yp.entity e on e.id=h.id
+      WHERE h.owner_id=_uid AND `serial`=0
+      INTO _wicket_id;
+
+      SELECT db_name FROM yp.entity WHERE id=_wicket_id INTO _wicket_db_name;
+
+      SET @s = CONCAT("
+            INSERT INTO _show_node
+            SELECT
+               t.ticket_id  , t.ticket_id , 'Support Ticket', NULL,NULL,NULL,NULL,NULL,NULL,c.ctime ,'personal','ticket'
+            FROM
+               yp.ticket t
+            INNER JOIN ", _wicket_db_name ,". map_ticket mt  ON  mt.ticket_id = t.ticket_id
+            INNER JOIN ", _wicket_db_name ,".channel c ON mt.message_id = c.message_id
+            LEFT JOIN yp.read_ticket_channel rtc on rtc.ticket_id = mt.ticket_id AND rtc.uid =?
+            WHERE t.uid =? AND c.sys_id > IFNULL(rtc.ref_sys_id,0)"
+
+      );
+      PREPARE stmt FROM @s;
+      EXECUTE stmt USING _uid,_uid;
+      DEALLOCATE PREPARE stmt;
+
+   ELSE
+
+      INSERT INTO _show_node
+      SELECT
+         t.ticket_id,  t.ticket_id ,'Support Ticket', NULL,NULL,NULL,NULL,NULL,NULL,c.ctime ,'personal','ticket'
+      FROM
+         yp.ticket t
+      LEFT JOIN yp.read_ticket_channel rtc on rtc.ticket_id = t.ticket_id AND rtc.uid = _uid
+      WHERE
+         t.last_sys_id > IFNULL(rtc.ref_sys_id,0)
+         AND CASE WHEN _is_support = 1 THEN t.uid ELSE _uid END = t.uid;
+
+   END IF;
+
+
+   SELECT
+      c.id contact_id,
+      d.id drumate_id,
+      dmu.id guest_id,
+      coalesce(c.id,  d.id,dmu.id,  CASE WHEN hub_id = 'Support Ticket' THEN entity_id WHEN b.category = 'teamchat' THEN COALESCE(b.nid, hub_id) ELSE hub_id END  ) key_id,
+      coalesce(c.firstname, d.firstname, dmu.email) firstname,
+      coalesce(c.lastname, d.lastname, dmu.email) lastname,
+      IF ( hub_id <>'Support Ticket' , (coalesce( IFNULL(c.surname,IF(coalesce(c.firstname, c.lastname) IS NULL,coalesce(ce.email,d.email,dmu.email),
+      CONCAT( IFNULL(c.firstname, '') ,' ',  IFNULL(c.lastname, '')))) ,  h.name )), entity_id  )surname,
+      coalesce(ce.email,d.email,dmu.email) email,
+      c.status status,
+      b.hub_id hub_id,
+      b.nid,
+      b.parent_id,
+      b.filename,
+      b.filetype,
+      b.item_filetype,
+      b.last_id,
+
+      b.ctime,
+      b.category,
+      b.cnt,
+      b.area,
+
+      (SELECT GROUP_CONCAT(t.tag_id) FROM
+      tag t INNER JOIN map_tag mt ON t.tag_id = mt.tag_id
+      WHERE mt.id = coalesce(c.id,  d.id,dmu.id,  CASE WHEN hub_id = 'Support Ticket' THEN entity_id ELSE hub_id END  )) as tag_id
+   FROM
+   (SELECT
+      count(1) cnt ,entity_id,hub_id,category,max(ctime) ctime ,area,
+      nid,
+      MAX(parent_id) parent_id,
+      MAX(filename) filename,
+      MAX(filetype) filetype,
+      MAX(item_filetype) item_filetype,
+      MAX(last_id) last_id
+   FROM  _show_node
+   GROUP BY entity_id,hub_id,category,area,nid ) b
+
+   LEFT JOIN yp.hub h ON h.id = b.hub_id
+   LEFT JOIN yp.dmz_user dmu ON b.entity_id = dmu.id
+   LEFT JOIN yp.drumate d ON b.entity_id = d.id
+   LEFT JOIN contact c ON  b.entity_id = c.uid  OR  b.entity_id = c.entity
+   LEFT JOIN contact_email ce ON ce.contact_id = c.id   AND ce.is_default = 1
+   ORDER BY b.ctime DESC;
+
+
+END $
+
+DELIMITER ;

--- a/drumate/procedures/notification/notification_dismiss.sql
+++ b/drumate/procedures/notification/notification_dismiss.sql
@@ -48,13 +48,23 @@ BEGIN
          AND ch.id <= _last_id;
 
     WHEN 'teamchat' THEN
-      -- Advance read_channel.ref_sys_id in the hub's per-hub DB
+      -- Per-folder: mark the caller `_seen_` on the target folder's delivered,
+      -- still-unseen messages instead of advancing the per-hub read_channel
+      -- pointer. _key_id is the folder nid (or the hub id for a hub-level/legacy
+      -- chat with no _scope_nid). Keeps notification_center_next's _seen_-based
+      -- unread consistent, so dismissing one folder's mentions does not clear a
+      -- sibling folder's.
       SELECT db_name INTO _hub_db FROM yp.entity WHERE id = _hub_id;
       IF _hub_db IS NOT NULL THEN
         SET @sql = CONCAT(
-          "INSERT INTO `", _hub_db, "`.read_channel (uid, ref_sys_id, ctime) ",
-          "VALUES ('", _uid, "', ", _last_id, ", ", _now, ") ",
-          "ON DUPLICATE KEY UPDATE ref_sys_id = GREATEST(VALUES(ref_sys_id), ref_sys_id), ctime = ", _now
+          "UPDATE `", _hub_db, "`.channel ",
+          "SET metadata = JSON_SET(IFNULL(metadata,'{}'), '$._seen_.", _uid, "', ", _now, ") ",
+          "WHERE status='active' AND author_id <> '", _uid, "' ",
+          "AND JSON_EXISTS(metadata,'$._delivered_.", _uid, "')=1 ",
+          "AND JSON_EXISTS(metadata,'$._seen_.", _uid, "')=0 ",
+          "AND ( JSON_UNQUOTE(JSON_EXTRACT(metadata,'$._scope_nid')) = '", _key_id, "' ",
+          "      OR (JSON_EXTRACT(metadata,'$._scope_nid') IS NULL AND '", _key_id, "' = '", _hub_id, "') ) ",
+          "AND (", IFNULL(_last_id, 0), " <= 0 OR sys_id <= ", IFNULL(_last_id, 0), ")"
         );
         PREPARE stmt FROM @sql;
         EXECUTE stmt;

--- a/drumate/procedures/notification/notification_read.sql
+++ b/drumate/procedures/notification/notification_read.sql
@@ -1,7 +1,9 @@
 -- File: schemas/drumate/procedures/notification/notification_read.sql
 -- Purpose: Mark a rollup as READ (advance read pointer) without hiding it
--- from the feed. For chat/teamchat/ticket the underlying schema only has a
--- read pointer, so read == dismiss. For contact/media we currently have no
+-- from the feed. For chat/ticket the underlying schema only has a read
+-- pointer, so read == dismiss. teamchat marks per-message `_seen_` on the
+-- target folder's delivered messages (per-folder, keeps notification_center_next
+-- unread consistent). For contact/media we currently have no
 -- separate `read_at` column, so we no-op here and let `notification_dismiss`
 -- be the only flag-setter — invoking this proc still advances the per-source
 -- read counters where they exist.
@@ -43,12 +45,23 @@ BEGIN
         mtime = _now;
 
     WHEN 'teamchat' THEN
+      -- Per-folder: mark the caller `_seen_` on the target folder's delivered,
+      -- still-unseen messages instead of advancing the per-hub read_channel
+      -- pointer. _key_id is the folder nid (or the hub id for a hub-level/legacy
+      -- chat with no _scope_nid). Keeps notification_center_next's _seen_-based
+      -- unread consistent, so reading one folder's mentions does not clear a
+      -- sibling folder's.
       SELECT db_name INTO _hub_db FROM yp.entity WHERE id = _hub_id;
       IF _hub_db IS NOT NULL THEN
         SET @sql = CONCAT(
-          "INSERT INTO `", _hub_db, "`.read_channel (uid, ref_sys_id, ctime) ",
-          "VALUES ('", _uid, "', ", _last_id, ", ", _now, ") ",
-          "ON DUPLICATE KEY UPDATE ref_sys_id = GREATEST(VALUES(ref_sys_id), ref_sys_id), ctime = ", _now
+          "UPDATE `", _hub_db, "`.channel ",
+          "SET metadata = JSON_SET(IFNULL(metadata,'{}'), '$._seen_.", _uid, "', ", _now, ") ",
+          "WHERE status='active' AND author_id <> '", _uid, "' ",
+          "AND JSON_EXISTS(metadata,'$._delivered_.", _uid, "')=1 ",
+          "AND JSON_EXISTS(metadata,'$._seen_.", _uid, "')=0 ",
+          "AND ( JSON_UNQUOTE(JSON_EXTRACT(metadata,'$._scope_nid')) = '", _key_id, "' ",
+          "      OR (JSON_EXTRACT(metadata,'$._scope_nid') IS NULL AND '", _key_id, "' = '", _hub_id, "') ) ",
+          "AND (", IFNULL(_last_id, 0), " <= 0 OR sys_id <= ", IFNULL(_last_id, 0), ")"
         );
         PREPARE stmt FROM @sql;
         EXECUTE stmt;

--- a/hub/procedures/channel/channel_list_notifications.sql
+++ b/hub/procedures/channel/channel_list_notifications.sql
@@ -21,6 +21,10 @@ BEGIN
     c.attachment,
     CASE WHEN LTRIM(RTRIM(c.attachment))='' OR c.attachment IS NULL THEN 0 ELSE 1 END is_attachment,
     c.ctime,
+    -- Folder a message was posted in for folder-scoped team chat (NULL for
+    -- hub-level messages). Lets the activity item deep-link a mention to the
+    -- originating folder's Chat tab instead of the hub root. Additive only.
+    JSON_UNQUOTE(JSON_EXTRACT(c.metadata, '$._scope_nid')) AS scope_nid,
     COALESCE(d.firstname, du.name, '') firstname,
     COALESCE(d.lastname, '') lastname,
     COALESCE(CONCAT(d.firstname, ' ', d.lastname), du.name, '') fullname,

--- a/hub/procedures/channel/message_reaction_toggle.sql
+++ b/hub/procedures/channel/message_reaction_toggle.sql
@@ -1,0 +1,115 @@
+-- File: schemas/hub/procedures/channel/message_reaction_toggle.sql
+-- =========================================================
+-- message_reaction_toggle  (HUB class — team chat + folder window)
+-- ONE reaction per user per message: a user holds at most one emoji.
+--   - Picking the user's current emoji again  -> remove it (toggle off).
+--   - Picking a different emoji               -> move the user to it (replace).
+-- Stored per-message in `channel`.metadata under `_reactions_`:
+--   { "<emoji>": ["<uid>", ...] }. Only the _reactions_ subpath is touched,
+-- so read-receipts (`_seen_`) and other metadata keys are preserved.
+--
+-- All writes operate DIRECTLY on `_meta` via JSON_REMOVE / JSON_ARRAY_APPEND /
+-- JSON_SET(..., JSON_ARRAY()). We never JSON_SET a string variable as the value
+-- (that double-encodes the sub-object into a quoted string). Atomic under
+-- concurrency (transaction + FOR UPDATE). Requires MariaDB 10.2.3+. Caller
+-- (service) validates emoji: single glyph, no quote/backslash/whitespace; uids
+-- are 16-char ascii hex (safe for the JSON_SEARCH removal below).
+--
+-- Returns one row: found (0 if message absent), capped (1 if a new emoji hit
+-- the distinct cap), reactions (the updated map as a JSON object).
+--
+-- Apply (DEV/STAGE ONLY — every hub instance on the server):
+--   bin/patch-from-file patches/message-reaction-toggle.sql hub
+-- =========================================================
+DELIMITER $
+
+DROP PROCEDURE IF EXISTS `message_reaction_toggle`$
+CREATE PROCEDURE `message_reaction_toggle`(
+  IN _message_id VARCHAR(16) CHARACTER SET ascii,
+  IN _uid VARCHAR(16) CHARACTER SET ascii,
+  IN _emoji VARCHAR(64) CHARACTER SET utf8mb4
+)
+BEGIN
+  DECLARE _meta LONGTEXT;
+  DECLARE _keys LONGTEXT;
+  DECLARE _arr LONGTEXT;
+  DECLARE _key VARCHAR(64) CHARACTER SET utf8mb4;
+  DECLARE _kpath VARCHAR(160);
+  DECLARE _epath VARCHAR(160);
+  DECLARE _hit VARCHAR(64);
+  DECLARE _n INT DEFAULT 0;
+  DECLARE _k INT DEFAULT 0;
+  DECLARE _was_mine INT DEFAULT 0;
+  DECLARE _capped INT DEFAULT 0;
+  DECLARE _exists INT DEFAULT 0;
+  DECLARE EXIT HANDLER FOR SQLEXCEPTION
+  BEGIN
+    ROLLBACK;
+    RESIGNAL;
+  END;
+
+  SET _epath = CONCAT('$._reactions_."', _emoji, '"');
+
+  START TRANSACTION;
+  SELECT COUNT(1) INTO _exists FROM `channel` WHERE message_id = _message_id;
+
+  IF _exists = 0 THEN
+    COMMIT;
+    SELECT 0 AS found, 0 AS capped, JSON_OBJECT() AS reactions;
+  ELSE
+    SELECT metadata INTO _meta FROM `channel` WHERE message_id = _message_id FOR UPDATE;
+    SET _meta = COALESCE(NULLIF(_meta, ''), '{}');
+    IF JSON_EXTRACT(_meta, '$._reactions_') IS NULL THEN
+      SET _meta = JSON_SET(_meta, '$._reactions_', JSON_OBJECT());
+    END IF;
+
+    -- Remove _uid from EVERY emoji array (one-per-user; also normalises any
+    -- legacy state where the user sat on multiple emojis). Operates on _meta
+    -- directly so nothing is re-encoded as a string.
+    SET _keys = COALESCE(JSON_KEYS(JSON_EXTRACT(_meta, '$._reactions_')), JSON_ARRAY());
+    SET _n = JSON_LENGTH(_keys);
+    SET _k = 0;
+    WHILE _k < _n DO
+      SET _key = JSON_UNQUOTE(JSON_EXTRACT(_keys, CONCAT('$[', _k, ']')));
+      SET _kpath = CONCAT('$._reactions_."', _key, '"');
+      SET _arr = JSON_EXTRACT(_meta, _kpath);
+      IF _arr IS NOT NULL AND JSON_CONTAINS(_arr, JSON_QUOTE(_uid)) THEN
+        -- Compare emojis with BINARY collation. The connection's default
+        -- utf8mb4_general_ci treats DISTINCT emojis as EQUAL ('👍' = '😮' is
+        -- TRUE), which made a switch (react 👍, then pick 😮) look like a
+        -- toggle-off: _was_mine was set, the old emoji was removed, and the new
+        -- one was NEVER added until a second call. utf8mb4_bin keeps same-emoji
+        -- equal (toggle-off still works) while distinguishing different emojis.
+        IF _key = _emoji COLLATE utf8mb4_bin THEN SET _was_mine = 1; END IF;
+        SET _hit = JSON_UNQUOTE(JSON_SEARCH(_arr, 'one', _uid));
+        IF _hit IS NOT NULL THEN
+          SET _meta = JSON_REMOVE(_meta, CONCAT(_kpath, SUBSTR(_hit, 2)));
+        END IF;
+        IF JSON_LENGTH(JSON_EXTRACT(_meta, _kpath)) = 0 THEN
+          SET _meta = JSON_REMOVE(_meta, _kpath);
+        END IF;
+      END IF;
+      SET _k = _k + 1;
+    END WHILE;
+
+    -- Re-add the user to the chosen emoji unless they toggled the same one off.
+    IF _was_mine = 0 THEN
+      IF JSON_EXTRACT(_meta, _epath) IS NULL THEN
+        IF JSON_LENGTH(JSON_EXTRACT(_meta, '$._reactions_')) < 50 THEN
+          SET _meta = JSON_SET(_meta, _epath, JSON_ARRAY(_uid));
+        ELSE
+          SET _capped = 1;
+        END IF;
+      ELSE
+        SET _meta = JSON_ARRAY_APPEND(_meta, _epath, _uid);
+      END IF;
+    END IF;
+
+    UPDATE `channel` SET metadata = _meta WHERE message_id = _message_id;
+    COMMIT;
+    SELECT 1 AS found, _capped AS capped,
+           COALESCE(JSON_EXTRACT(_meta, '$._reactions_'), JSON_OBJECT()) AS reactions;
+  END IF;
+END $
+
+DELIMITER ;


### PR DESCRIPTION
## What
Ports stored procs that have lived **only as server-team live patches on stage** into the canonical `schemas` repo, so they survive a rebuild and can reach prod through the normal `test → preview → main` flow.

## Files
**Per-folder team-chat notifications** (the coherent unit):
| File | Class | Change |
|---|---|---|
| `drumate/.../notification/notification_center_next.sql` | drumate | **NEW** rollup proc — one row per folder-scoped chat; `key_id`=folder nid; unread = `_delivered_` set AND `_seen_` unset |
| `drumate/.../notification/notification_read.sql` | drumate | teamchat branch: per-hub `read_channel` pointer → per-message `_seen_` on the target folder |
| `drumate/.../notification/notification_dismiss.sql` | drumate | same teamchat rework |
| `hub/.../channel/channel_list_notifications.sql` | hub | **additive** column `scope_nid` (= `metadata._scope_nid`) for folder deep-link |

**Chat reactions** (independent feature, separate commit):
| File | Class | Change |
|---|---|---|
| `hub/.../channel/message_reaction_toggle.sql` | hub | **NEW** — emoji toggle on team-chat/folder messages |
| `drumate/.../chat/p2p_message_reaction_toggle.sql` | drumate | **NEW** — emoji toggle on P2P/DM messages |

## ⚠️ Review gate — @Vu Dang
The teamchat branch in `notification_read` / `notification_dismiss` **replaces the per-hub `read_channel` model you authored (2026-05-08)** with a per-folder `_seen_` model. Non-teamchat branches (chat/media/ticket/contact) are untouched. Please confirm the per-folder model is OK to adopt — this is the agreed direction (folder-scoped unread).

## Deploy coupling (do NOT merge/deploy in isolation)
1. **FE must ship together**: activity panel per-folder nav + chat in-scope ack (ui-team). Applying these procs while prod FE is the old version will leave folder-chat dismiss/nav broken.
2. **server-team `service/private/channel.js`** (mention delivery, `_delivered_`/`mention_ids`) must deploy in the same release.
3. **Known limitation (unresolved):** if a recipient has the folder chat open, the live widget auto-acks `_seen_`, so a mention may not surface in the list (per-folder `_seen_` is read-coupled). Acceptable for now per product owner; tracked separately.

## Deploy (for DevOps)
- New/changed procs apply per **db class**: 4 × `drumate`, 2 × `hub`.
- Regenerate manifest: `bin/make-manifest <prod_hash> HEAD`; or apply directly: `bin/patch-from-file <file> <drumate|hub>` (class fan-out applies to all instances).
- Reactions are independent and lower-risk; can be deployed separately from notifications.