### PR TITLE
feat(channel): per-file chat threads + scoped message search

### DIFF
--- a/common/procedures/channel/channel_search_scoped.sql
+++ b/common/procedures/channel/channel_search_scoped.sql
@@ -1,0 +1,46 @@
+DELIMITER $
+DROP PROCEDURE IF EXISTS `channel_search_scoped`$
+CREATE PROCEDURE `channel_search_scoped`(
+  IN _uid VARCHAR(16),
+  IN _pattern MEDIUMTEXT,
+  IN _file_thread_id VARCHAR(16)
+)
+BEGIN
+  -- Full-text-ish (LIKE) search over the current hub's channel messages, scoped
+  -- to ONE conversation:
+  --   _file_thread_id NULL/'' -> the workspace/folder team chat (file_thread_id IS NULL)
+  --   _file_thread_id set      -> that file thread's child messages (file_thread_id = _file_thread_id)
+  -- Excludes messages the caller deleted for themselves (delete_channel), so the
+  -- result set matches what the user actually sees in the conversation. Mirrors
+  -- channel_search's projection (+ author name) plus the scope + per-user delete
+  -- filter. hub_id is tagged by the service layer. preview capped at 150 chars;
+  -- newest first; capped at 45 rows.
+  SELECT
+    'message' AS result_type,
+    c.message_id AS id,
+    c.message_id,
+    c.author_id,
+    c.ctime,
+    SUBSTRING(c.message, 1, 150) AS preview,
+    COALESCE(d.firstname, du.name, '') firstname,
+    COALESCE(d.lastname, '') lastname,
+    COALESCE(CONCAT(d.firstname, ' ', d.lastname), du.name, '') fullname
+  FROM channel c
+  LEFT JOIN yp.drumate d  ON c.author_id = d.id
+  LEFT JOIN yp.dmz_user du ON c.author_id = du.id
+  WHERE c.status = 'active'
+    AND c.message IS NOT NULL
+    AND c.message LIKE CONCAT('%', _pattern, '%')
+    AND NOT EXISTS (
+      SELECT 1 FROM delete_channel dc
+      WHERE dc.uid = _uid AND dc.ref_sys_id = c.sys_id
+    )
+    AND (
+      ( (_file_thread_id IS NULL OR _file_thread_id = '') AND c.file_thread_id IS NULL )
+      OR
+      ( _file_thread_id IS NOT NULL AND _file_thread_id <> '' AND c.file_thread_id = _file_thread_id )
+    )
+  ORDER BY c.ctime DESC
+  LIMIT 45;
+END $
+DELIMITER ;

--- a/drumate/procedures/notification/notification_center_next.sql
+++ b/drumate/procedures/notification/notification_center_next.sql
@@ -75,9 +75,13 @@ DECLARE _wicket_id VARCHAR(16);
       -- the activity item shows the folder name and opens it. Unread is per-message
       -- (delivered AND not _seen_), matching channel_list_notifications, so reading
       -- one folder's messages does not clear a sibling folder's mentions.
+      -- File-thread CHILD replies (channel.file_thread_id IS NOT NULL) are
+      -- excluded here so they do not spam the folder unread count; the folder
+      -- shows exactly one unread item per thread (the root system card). Thread
+      -- replies still notify via @mention through the separate mention category.
       SET @sql=  CONCAT(
          "INSERT INTO _show_node
-         SELECT c.message_id,'", _nid ,"','",_nid, "' As hub_id , JSON_UNQUOTE(JSON_EXTRACT(c.metadata,'$._scope_nid')), sf.parent_id, sf.user_filename, 'folder', NULL, c.sys_id, c.ctime,'", _area, "','teamchat'  FROM ", _db_name ,".channel c LEFT JOIN ", _db_name ,".media sf ON sf.id = JSON_UNQUOTE(JSON_EXTRACT(c.metadata,'$._scope_nid')) WHERE c.status='active' AND c.author_id <> '", _uid ,"' AND JSON_EXISTS(c.metadata,'$._delivered_.", _uid ,"')=1 AND JSON_EXISTS(c.metadata,'$._seen_.", _uid ,"')=0" ) ;
+         SELECT c.message_id,'", _nid ,"','",_nid, "' As hub_id , JSON_UNQUOTE(JSON_EXTRACT(c.metadata,'$._scope_nid')), sf.parent_id, sf.user_filename, 'folder', NULL, c.sys_id, c.ctime,'", _area, "','teamchat'  FROM ", _db_name ,".channel c LEFT JOIN ", _db_name ,".media sf ON sf.id = JSON_UNQUOTE(JSON_EXTRACT(c.metadata,'$._scope_nid')) WHERE c.status='active' AND c.author_id <> '", _uid ,"' AND JSON_EXISTS(c.metadata,'$._delivered_.", _uid ,"')=1 AND JSON_EXISTS(c.metadata,'$._seen_.", _uid ,"')=0 AND c.file_thread_id IS NULL" ) ;
       EXECUTE IMMEDIATE @sql;
 
       SET @s = CONCAT(

--- a/hub/patches/2026-06-26-channel-file-thread.sql
+++ b/hub/patches/2026-06-26-channel-file-thread.sql
@@ -1,0 +1,60 @@
+-- File Chat Threads — schema migration for existing hub databases.
+-- Run once per hub DB (stage + production). Fully idempotent.
+--
+-- 1) channel.file_thread_id : membership marker for a per-file chat child message.
+--    NULL = normal message (incl. the folder-visible "file.thread" root card);
+--    non-NULL = child message belonging to that file thread (root_message_id).
+--    thread_id stays reply-to-message; the two are intentionally separate.
+-- 2) channel_file_thread_idx : paginated lookup of a thread's children.
+-- 3) file_thread table : one row per file that has a chat thread.
+--
+-- Apply via:  bin/patch-from-file hub/patches/2026-06-26-channel-file-thread.sql hub
+--   or:       mariadb <hub_db_name> < 2026-06-26-channel-file-thread.sql
+
+-- ---- 1) channel.file_thread_id column -------------------------------------
+SET @col_exists = (
+  SELECT COUNT(*)
+  FROM information_schema.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME   = 'channel'
+    AND COLUMN_NAME  = 'file_thread_id'
+);
+SET @sql = IF(
+  @col_exists = 0,
+  'ALTER TABLE `channel` ADD COLUMN `file_thread_id` varchar(16) CHARACTER SET ascii COLLATE ascii_general_ci DEFAULT NULL AFTER `thread_id`',
+  'SELECT "channel.file_thread_id already exists — skipped" AS info'
+);
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- ---- 2) channel_file_thread_idx index -------------------------------------
+SET @idx_exists = (
+  SELECT COUNT(*)
+  FROM information_schema.STATISTICS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME   = 'channel'
+    AND INDEX_NAME   = 'channel_file_thread_idx'
+);
+SET @sql = IF(
+  @idx_exists = 0,
+  'ALTER TABLE `channel` ADD KEY `channel_file_thread_idx` (`file_thread_id`, `sys_id`)',
+  'SELECT "channel_file_thread_idx already exists — skipped" AS info'
+);
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- ---- 3) file_thread table --------------------------------------------------
+CREATE TABLE IF NOT EXISTS `file_thread` (
+  `sys_id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `file_nid` varchar(16) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL,
+  `folder_nid` varchar(16) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL,
+  `root_message_id` varchar(16) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL,
+  `created_by` varchar(16) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL,
+  `last_message_id` varchar(16) CHARACTER SET ascii COLLATE ascii_general_ci DEFAULT NULL,
+  `reply_count` int(11) unsigned NOT NULL DEFAULT 0,
+  `ctime` int(11) NOT NULL,
+  `mtime` int(11) NOT NULL,
+  `status` enum('active','deleted') NOT NULL DEFAULT 'active',
+  PRIMARY KEY (`sys_id`),
+  UNIQUE KEY `file_thread_file_uidx` (`file_nid`),
+  UNIQUE KEY `file_thread_root_uidx` (`root_message_id`),
+  KEY `file_thread_folder_idx` (`folder_nid`, `status`, `mtime`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;

--- a/hub/procedures/channel/channel_export_count.sql
+++ b/hub/procedures/channel/channel_export_count.sql
@@ -1,0 +1,38 @@
+DELIMITER $
+
+-- =========================================================
+-- channel_export_count
+-- Fast COUNT of hub team-chat messages (file_thread_id IS NULL)
+-- for the given uid and optional date range. Used by the
+-- 10k guard in channel.export before gathering begins.
+-- Date bounds arrive as VARCHAR: the mariadb layer converts a
+-- JS null param to '' (empty string), which an INT(11) IN-param
+-- rejects under strict SQL mode. Accept text, normalise '' / NULL
+-- to a NULL bound (no filter) and CAST numeric strings to epoch.
+-- READ-ONLY: no UPDATE / INSERT.
+-- =========================================================
+DROP PROCEDURE IF EXISTS `channel_export_count`$
+CREATE PROCEDURE `channel_export_count`(
+  IN _uid        VARCHAR(16),
+  IN _date_start VARCHAR(20),
+  IN _date_end   VARCHAR(20)
+)
+BEGIN
+  DECLARE ds BIGINT DEFAULT NULL;
+  DECLARE de BIGINT DEFAULT NULL;
+  IF _date_start IS NOT NULL AND _date_start <> '' THEN SET ds = CAST(_date_start AS UNSIGNED); END IF;
+  IF _date_end   IS NOT NULL AND _date_end   <> '' THEN SET de = CAST(_date_end   AS UNSIGNED); END IF;
+
+  SELECT COUNT(*) AS message_count
+  FROM channel c
+  WHERE
+    c.file_thread_id IS NULL
+    AND NOT EXISTS (
+      SELECT 1 FROM delete_channel
+      WHERE uid = _uid AND ref_sys_id = c.sys_id
+    )
+    AND (ds IS NULL OR c.ctime >= ds)
+    AND (de IS NULL OR c.ctime <= de);
+END $
+
+DELIMITER ;

--- a/hub/procedures/channel/channel_export_file_thread_count.sql
+++ b/hub/procedures/channel/channel_export_file_thread_count.sql
@@ -1,0 +1,36 @@
+DELIMITER $
+
+-- =========================================================
+-- channel_export_file_thread_count
+-- Count messages in ONE file thread for the 10k export guard.
+-- Date bounds arrive as VARCHAR and are NULL-safe: '' / NULL =
+-- no filter (the mariadb layer sends '' for a JS null param,
+-- which an INT(11) IN-param rejects in strict SQL mode).
+-- READ-ONLY: no UPDATE / INSERT.
+-- =========================================================
+DROP PROCEDURE IF EXISTS `channel_export_file_thread_count`$
+CREATE PROCEDURE `channel_export_file_thread_count`(
+  IN _uid            VARCHAR(16),
+  IN _file_thread_id VARCHAR(16),
+  IN _date_start     VARCHAR(20),
+  IN _date_end       VARCHAR(20)
+)
+BEGIN
+  DECLARE ds BIGINT DEFAULT NULL;
+  DECLARE de BIGINT DEFAULT NULL;
+  IF _date_start IS NOT NULL AND _date_start <> '' THEN SET ds = CAST(_date_start AS UNSIGNED); END IF;
+  IF _date_end   IS NOT NULL AND _date_end   <> '' THEN SET de = CAST(_date_end   AS UNSIGNED); END IF;
+
+  SELECT COUNT(*) AS message_count
+  FROM channel c
+  WHERE
+    c.file_thread_id = _file_thread_id
+    AND NOT EXISTS (
+      SELECT 1 FROM delete_channel
+      WHERE uid = _uid AND ref_sys_id = c.sys_id
+    )
+    AND (ds IS NULL OR c.ctime >= ds)
+    AND (de IS NULL OR c.ctime <= de);
+END $
+
+DELIMITER ;

--- a/hub/procedures/channel/channel_export_file_thread_list.sql
+++ b/hub/procedures/channel/channel_export_file_thread_list.sql
@@ -1,0 +1,26 @@
+DELIMITER $
+
+-- =========================================================
+-- channel_export_file_thread_list
+-- Hub-wide list of active file threads with resolved filename.
+-- Used by channel.export_scope to enumerate all file threads
+-- the user may include in an export. Single-hub DB context.
+-- No pagination — export scope UI renders the full list once.
+-- =========================================================
+DROP PROCEDURE IF EXISTS `channel_export_file_thread_list`$
+CREATE PROCEDURE `channel_export_file_thread_list`(
+  IN _uid VARCHAR(16)
+)
+BEGIN
+  SELECT
+    ft.root_message_id AS file_thread_id,
+    ft.file_nid,
+    m.user_filename    AS filename,
+    ft.reply_count
+  FROM file_thread ft
+  INNER JOIN media m ON m.id = ft.file_nid
+  WHERE ft.status = 'active'
+  ORDER BY ft.mtime DESC;
+END $
+
+DELIMITER ;

--- a/hub/procedures/channel/channel_export_file_thread_messages.sql
+++ b/hub/procedures/channel/channel_export_file_thread_messages.sql
@@ -1,0 +1,72 @@
+DELIMITER $
+
+-- =========================================================
+-- channel_export_file_thread_messages
+-- READ-ONLY clone of channel_file_thread_list_messages.
+-- Differences from the original:
+--   1. The mark-seen block (UPDATE channel metadata._seen_)
+--      is entirely ABSENT — export must not alter read state.
+--   2. Date-range filter: NULL/'' bound = no constraint. Bounds
+--      arrive as VARCHAR because the mariadb layer sends '' for a
+--      JS null param, which an INT(11) IN-param rejects in strict
+--      mode.
+--   3. ORDER BY ctime ASC (export order, oldest first).
+--   4. No _order param — always ascending ctime.
+-- =========================================================
+DROP PROCEDURE IF EXISTS `channel_export_file_thread_messages`$
+CREATE PROCEDURE `channel_export_file_thread_messages`(
+  IN _uid            VARCHAR(16),
+  IN _file_thread_id VARCHAR(16),
+  IN _date_start     VARCHAR(20),
+  IN _date_end       VARCHAR(20),
+  IN _page           TINYINT(4)
+)
+BEGIN
+  DECLARE _range  BIGINT;
+  DECLARE _offset BIGINT;
+  DECLARE ds BIGINT DEFAULT NULL;
+  DECLARE de BIGINT DEFAULT NULL;
+  IF _date_start IS NOT NULL AND _date_start <> '' THEN SET ds = CAST(_date_start AS UNSIGNED); END IF;
+  IF _date_end   IS NOT NULL AND _date_end   <> '' THEN SET de = CAST(_date_end   AS UNSIGNED); END IF;
+  CALL pageToLimits(_page, _offset, _range);
+
+  SELECT
+    _page AS `page`,
+    c.sys_id,
+    c.author_id,
+    c.message,
+    c.message_id,
+    c.thread_id,
+    c.file_thread_id,
+    c.is_forward,
+    c.mention_ids,
+    c.attachment,
+    CASE WHEN LTRIM(RTRIM(c.attachment)) = '' OR c.attachment IS NULL THEN 0 ELSE 1 END AS is_attachment,
+    c.status,
+    c.ctime,
+    c.metadata,
+    COALESCE(d.firstname, du.name, '')                           AS firstname,
+    COALESCE(d.lastname, '')                                     AS lastname,
+    COALESCE(CONCAT(d.firstname, ' ', d.lastname), du.name, '') AS fullname,
+    IFNULL(read_json_object(c.metadata, 'message_type'), 'chat') AS message_type,
+    read_json_object(c.metadata, 'call_status')                  AS call_status
+  FROM (
+    SELECT sys_id FROM channel c
+    WHERE
+      c.file_thread_id = _file_thread_id
+      AND NOT EXISTS (
+        SELECT 1 FROM delete_channel
+        WHERE uid = _uid AND ref_sys_id = c.sys_id
+      )
+      AND (ds IS NULL OR c.ctime >= ds)
+      AND (de IS NULL OR c.ctime <= de)
+    ORDER BY c.sys_id ASC
+    LIMIT _offset, _range
+  ) s
+  INNER JOIN channel c   ON c.sys_id = s.sys_id
+  LEFT  JOIN yp.drumate d   ON c.author_id = d.id
+  LEFT  JOIN yp.dmz_user du ON c.author_id = du.id
+  ORDER BY c.sys_id ASC;
+END $
+
+DELIMITER ;

--- a/hub/procedures/channel/channel_export_messages.sql
+++ b/hub/procedures/channel/channel_export_messages.sql
@@ -1,0 +1,71 @@
+DELIMITER $
+
+-- =========================================================
+-- channel_export_messages
+-- READ-ONLY clone of channel_list_messages.
+-- Differences from the original:
+--   1. The mark-seen block (UPDATE channel metadata._seen_ +
+--      INSERT read_channel) is entirely ABSENT — export must
+--      not alter any read state.
+--   2. Date-range filter: NULL/'' bound = no constraint (export
+--      full history when client omits dates). Bounds arrive as
+--      VARCHAR because the mariadb layer sends '' for a JS null
+--      param, which an INT(11) IN-param rejects in strict mode.
+--   3. ORDER BY ctime ASC (export order, oldest first).
+--   4. No _sort_by / _order params — always ascending ctime.
+-- =========================================================
+DROP PROCEDURE IF EXISTS `channel_export_messages`$
+CREATE PROCEDURE `channel_export_messages`(
+  IN _uid        VARCHAR(16),
+  IN _date_start VARCHAR(20),
+  IN _date_end   VARCHAR(20),
+  IN _page       TINYINT(4)
+)
+BEGIN
+  DECLARE _range  BIGINT;
+  DECLARE _offset BIGINT;
+  DECLARE ds BIGINT DEFAULT NULL;
+  DECLARE de BIGINT DEFAULT NULL;
+  IF _date_start IS NOT NULL AND _date_start <> '' THEN SET ds = CAST(_date_start AS UNSIGNED); END IF;
+  IF _date_end   IS NOT NULL AND _date_end   <> '' THEN SET de = CAST(_date_end   AS UNSIGNED); END IF;
+  CALL pageToLimits(_page, _offset, _range);
+
+  SELECT
+    _page AS `page`,
+    c.sys_id,
+    c.author_id,
+    c.message,
+    c.message_id,
+    c.thread_id,
+    c.file_thread_id,
+    c.is_forward,
+    c.mention_ids,
+    c.attachment,
+    CASE WHEN LTRIM(RTRIM(c.attachment)) = '' OR c.attachment IS NULL THEN 0 ELSE 1 END AS is_attachment,
+    c.status,
+    c.ctime,
+    c.metadata,
+    IFNULL(read_json_object(c.metadata, 'message_type'), 'chat') AS message_type,
+    COALESCE(d.firstname, du.name, '')                           AS firstname,
+    COALESCE(d.lastname, '')                                     AS lastname,
+    COALESCE(CONCAT(d.firstname, ' ', d.lastname), du.name, '') AS fullname
+  FROM (
+    SELECT sys_id FROM channel c
+    WHERE
+      NOT EXISTS (
+        SELECT 1 FROM delete_channel
+        WHERE uid = _uid AND ref_sys_id = c.sys_id
+      )
+      AND c.file_thread_id IS NULL
+      AND (ds IS NULL OR c.ctime >= ds)
+      AND (de IS NULL OR c.ctime <= de)
+    ORDER BY c.sys_id ASC
+    LIMIT _offset, _range
+  ) s
+  INNER JOIN channel c  ON c.sys_id = s.sys_id
+  LEFT  JOIN yp.drumate d  ON c.author_id = d.id
+  LEFT  JOIN yp.dmz_user du ON c.author_id = du.id
+  ORDER BY c.sys_id ASC;
+END $
+
+DELIMITER ;

--- a/hub/procedures/channel/channel_file_thread_ensure_root.sql
+++ b/hub/procedures/channel/channel_file_thread_ensure_root.sql
@@ -1,0 +1,102 @@
+DELIMITER $
+
+-- =========================================================
+-- channel_file_thread_ensure_root
+-- Atomically reserve the per-file chat thread for _file_nid and the
+-- folder-visible "file.thread" root system card, if not already present.
+-- Race-safe: UNIQUE(file_nid) guarantees exactly one thread per file even
+-- under concurrent first sends. The winner's _root_message_id wins; losers
+-- adopt the existing root_message_id (service MUST use the returned one).
+-- Returns: file_nid, folder_nid, file_thread_id (=root_message_id), is_new.
+-- =========================================================
+DROP PROCEDURE IF EXISTS `channel_file_thread_ensure_root`$
+CREATE PROCEDURE `channel_file_thread_ensure_root`(
+  IN _file_nid VARCHAR(16),
+  IN _folder_nid VARCHAR(16),
+  IN _root_message_id VARCHAR(16),
+  IN _uid VARCHAR(16)
+)
+BEGIN
+  DECLARE _now INT(11) UNSIGNED;
+  DECLARE _dup INT DEFAULT 0;
+  DECLARE _eff_root VARCHAR(16) CHARACTER SET ascii DEFAULT NULL;
+  DECLARE _eff_folder VARCHAR(16) CHARACTER SET ascii DEFAULT NULL;
+  DECLARE _is_new INT DEFAULT 0;
+  DECLARE _member VARCHAR(16) CHARACTER SET ascii;
+  DECLARE _done INT DEFAULT 0;
+  DECLARE member_cursor CURSOR FOR
+    SELECT d.id
+    FROM permission p
+    INNER JOIN yp.drumate d ON p.entity_id = d.id
+    WHERE p.resource_id = '*' AND d.id <> _uid;
+  DECLARE CONTINUE HANDLER FOR NOT FOUND SET _done = 1;
+
+  SET _now = UNIX_TIMESTAMP();
+  SET _dup = 0;
+
+  -- Scope the duplicate-key handler to ONLY the thread-reservation INSERT, so
+  -- the UNIQUE(file_nid) race is absorbed here while any OTHER integrity error
+  -- later in the proc surfaces instead of being silently swallowed.
+  BEGIN
+    DECLARE CONTINUE HANDLER FOR SQLSTATE '23000' SET _dup = 1;
+    INSERT INTO file_thread (file_nid, folder_nid, root_message_id, created_by, last_message_id, reply_count, ctime, mtime, status)
+    VALUES (_file_nid, _folder_nid, _root_message_id, _uid, NULL, 0, _now, _now, 'active');
+  END;
+
+  IF _dup = 1 THEN
+    -- Another concurrent sender created this thread first; adopt its root.
+    SET _is_new = 0;
+    SELECT root_message_id, folder_nid INTO _eff_root, _eff_folder
+      FROM file_thread WHERE file_nid = _file_nid AND status = 'active' LIMIT 1;
+  ELSE
+    SET _is_new = 1;
+    SET _eff_root = _root_message_id;
+    SET _eff_folder = _folder_nid;
+  END IF;
+
+  -- Ensure the folder-visible root system card exists (idempotent). The card
+  -- is a normal channel row: file_thread_id NULL (it is not a child),
+  -- metadata.message_type 'file.thread', scoped to the folder via _scope_nid.
+  INSERT IGNORE INTO channel (message_id, author_id, message, thread_id, file_thread_id, ctime, attachment, mention_ids, metadata)
+  SELECT _eff_root, _uid, NULL, NULL, NULL, _now, NULL, NULL,
+    JSON_OBJECT(
+      'message_type', 'file.thread',
+      '_scope_nid', _eff_folder,
+      '_file_thread_root', 1,
+      '_file_thread_id', _eff_root,
+      '_file_nid', _file_nid
+    );
+
+  -- Seed per-message seen/delivered for the creator so the card is not its own
+  -- unread item; only applied if not already present.
+  UPDATE channel SET metadata = JSON_MERGE(
+      IFNULL(metadata, '{}'),
+      JSON_OBJECT('_seen_', JSON_OBJECT(_uid, 1)),
+      JSON_OBJECT('_delivered_', JSON_OBJECT(_uid, _now))
+    )
+    WHERE message_id = _eff_root
+    AND JSON_EXISTS(metadata, CONCAT('$._seen_.', _uid)) = 0;
+
+  -- Deliver the root card to every hub member (excluding the creator) so the
+  -- notification center counts it as ONE unread folder item per thread. Mirrors
+  -- the delivery cursor in channel_post_message. Idempotent (JSON_SET), so it is
+  -- safe even if a concurrent caller already delivered the same card.
+  SET _done = 0;
+  OPEN member_cursor;
+    read_loop: LOOP
+      FETCH member_cursor INTO _member;
+      IF _done = 1 THEN LEAVE read_loop; END IF;
+      UPDATE channel SET metadata = JSON_SET(metadata, CONCAT('$._delivered_.', _member), _now)
+        WHERE message_id = _eff_root AND _member IS NOT NULL;
+    END LOOP read_loop;
+  CLOSE member_cursor;
+
+  SELECT
+    _file_nid AS file_nid,
+    _eff_folder AS folder_nid,
+    _eff_root AS file_thread_id,
+    _eff_root AS root_message_id,
+    _is_new AS is_new;
+END $
+
+DELIMITER ;

--- a/hub/procedures/channel/channel_file_thread_info.sql
+++ b/hub/procedures/channel/channel_file_thread_info.sql
@@ -1,0 +1,70 @@
+DELIMITER $
+
+-- =========================================================
+-- channel_file_thread_info
+-- Lookup a file chat thread by _file_nid OR _file_thread_id (root_message_id).
+-- Always returns current file metadata (hydrated from media), so the UI can
+-- render the file chat header / card even before a thread exists.
+-- exists_thread = 1 only when an active thread row is present.
+-- NOTE: permission to read the file is validated by the service
+-- (mfs_access_node); the proc only returns data.
+-- =========================================================
+DROP PROCEDURE IF EXISTS `channel_file_thread_info`$
+CREATE PROCEDURE `channel_file_thread_info`(
+  IN _uid VARCHAR(16),
+  IN _file_nid VARCHAR(16),
+  IN _file_thread_id VARCHAR(16)
+)
+BEGIN
+  IF _file_nid IS NOT NULL AND _file_nid <> '' THEN
+    SELECT
+      CASE WHEN ft.sys_id IS NOT NULL THEN 1 ELSE 0 END AS exists_thread,
+      m.id AS file_nid,
+      m.parent_id AS folder_nid,
+      ft.root_message_id AS file_thread_id,
+      ft.created_by,
+      ft.last_message_id,
+      ft.reply_count,
+      ft.mtime,
+      ft.ctime,
+      m.user_filename,
+      m.extension,
+      m.category,
+      m.status AS media_status,
+      m.file_path,
+      cd.firstname AS created_firstname,
+      cd.lastname AS created_lastname,
+      COALESCE(CONCAT(cd.firstname, ' ', cd.lastname), cd.firstname, du.name, '') AS created_fullname
+    FROM media m
+    LEFT JOIN file_thread ft ON ft.file_nid = m.id AND ft.status = 'active'
+    LEFT JOIN yp.drumate cd ON cd.id = ft.created_by
+    LEFT JOIN yp.dmz_user du ON du.id = ft.created_by
+    WHERE m.id = _file_nid;
+  ELSE
+    SELECT
+      CASE WHEN ft.sys_id IS NOT NULL THEN 1 ELSE 0 END AS exists_thread,
+      ft.file_nid,
+      ft.folder_nid,
+      ft.root_message_id AS file_thread_id,
+      ft.created_by,
+      ft.last_message_id,
+      ft.reply_count,
+      ft.mtime,
+      ft.ctime,
+      m.user_filename,
+      m.extension,
+      m.category,
+      m.status AS media_status,
+      m.file_path,
+      cd.firstname AS created_firstname,
+      cd.lastname AS created_lastname,
+      COALESCE(CONCAT(cd.firstname, ' ', cd.lastname), cd.firstname, du.name, '') AS created_fullname
+    FROM file_thread ft
+    LEFT JOIN media m ON m.id = ft.file_nid
+    LEFT JOIN yp.drumate cd ON cd.id = ft.created_by
+    LEFT JOIN yp.dmz_user du ON du.id = ft.created_by
+    WHERE ft.root_message_id = _file_thread_id AND ft.status = 'active';
+  END IF;
+END $
+
+DELIMITER ;

--- a/hub/procedures/channel/channel_file_thread_list_by_folder.sql
+++ b/hub/procedures/channel/channel_file_thread_list_by_folder.sql
@@ -1,0 +1,53 @@
+DELIMITER $
+
+-- =========================================================
+-- channel_file_thread_list_by_folder
+-- Existing active file threads for files that are CURRENT direct children of
+-- _folder_nid. Folder membership follows media.parent_id (source of truth), NOT
+-- file_thread.folder_nid (creation context). A moved file therefore surfaces
+-- only under its current parent. Files without a thread never appear here.
+-- =========================================================
+DROP PROCEDURE IF EXISTS `channel_file_thread_list_by_folder`$
+CREATE PROCEDURE `channel_file_thread_list_by_folder`(
+  IN _uid VARCHAR(16),
+  IN _folder_nid VARCHAR(16),
+  IN _order VARCHAR(20),
+  IN _page TINYINT(4)
+)
+BEGIN
+  DECLARE _range bigint;
+  DECLARE _offset bigint;
+  DECLARE _dir VARCHAR(4) DEFAULT 'DESC';
+  CALL pageToLimits(_page, _offset, _range);
+  IF _order = 'asc' THEN
+    SET _dir = 'ASC';
+  END IF;
+
+  SET @sql = CONCAT(
+    'SELECT',
+    '   ft.file_nid,',
+    '   ft.root_message_id AS file_thread_id,',
+    '   ft.folder_nid AS created_folder_nid,',
+    '   m.parent_id AS folder_nid,',
+    '   ft.created_by,',
+    '   ft.reply_count,',
+    '   ft.last_message_id,',
+    '   ft.mtime,',
+    '   ft.ctime,',
+    '   m.user_filename,',
+    '   m.extension,',
+    '   m.category,',
+    '   m.status AS media_status',
+    ' FROM file_thread ft',
+    ' INNER JOIN media m ON m.id = ft.file_nid',
+    ' WHERE ft.status = ''active''',
+    '   AND m.parent_id = ''', _folder_nid, '''',
+    ' ORDER BY ft.mtime ', _dir,
+    ' LIMIT ', _offset, ', ', _range
+  );
+  PREPARE stmt FROM @sql;
+  EXECUTE stmt;
+  DEALLOCATE PREPARE stmt;
+END $
+
+DELIMITER ;

--- a/hub/procedures/channel/channel_file_thread_list_messages.sql
+++ b/hub/procedures/channel/channel_file_thread_list_messages.sql
@@ -1,0 +1,72 @@
+DELIMITER $
+
+-- =========================================================
+-- channel_file_thread_list_messages
+-- Child messages of one file thread (channel.file_thread_id = _file_thread_id),
+-- enriched with the same author/entity/read shape as channel_list_messages.
+-- Marks THIS thread's messages seen up to the page boundary on open — scoped
+-- to file_thread_id so it never touches sibling folder/workspace read state.
+-- =========================================================
+DROP PROCEDURE IF EXISTS `channel_file_thread_list_messages`$
+CREATE PROCEDURE `channel_file_thread_list_messages`(
+  IN _uid VARCHAR(16),
+  IN _file_thread_id VARCHAR(16),
+  IN _order VARCHAR(20),
+  IN _page TINYINT(4)
+)
+BEGIN
+  DECLARE _range bigint;
+  DECLARE _offset bigint;
+  DECLARE _ref_sys_id int(11) unsigned default 0;
+  CALL pageToLimits(_page, _offset, _range);
+
+  SELECT sys_id INTO _ref_sys_id FROM (
+    SELECT sys_id FROM channel c
+    WHERE c.file_thread_id = _file_thread_id
+      AND NOT EXISTS( SELECT 1 FROM delete_channel WHERE uid = _uid AND ref_sys_id = c.sys_id)
+    ORDER BY c.sys_id DESC LIMIT _offset, _range
+  ) a ORDER BY sys_id DESC LIMIT 1;
+
+  IF _ref_sys_id > 0 THEN
+    UPDATE channel SET metadata = JSON_SET(metadata, CONCAT('$._seen_.', _uid), UNIX_TIMESTAMP())
+    WHERE file_thread_id = _file_thread_id
+      AND sys_id <= _ref_sys_id
+      AND JSON_EXISTS(metadata, CONCAT('$._seen_.', _uid)) = 0;
+  END IF;
+
+  SELECT
+    _page AS `page`,
+    c.sys_id,
+    c.author_id,
+    c.message,
+    c.message_id,
+    c.thread_id,
+    c.file_thread_id,
+    c.is_forward,
+    c.mention_ids,
+    c.attachment,
+    CASE WHEN LTRIM(RTRIM(c.attachment))='' OR c.attachment IS NULL THEN 0 ELSE 1 END is_attachment,
+    c.status,
+    c.ctime,
+    c.metadata,
+    COALESCE(d.firstname, du.name, '') firstname,
+    COALESCE(d.lastname, '') lastname,
+    COALESCE(CONCAT(d.firstname, ' ', d.lastname), du.name, '') fullname,
+    CASE WHEN JSON_EXISTS(c.metadata, CONCAT('$._seen_.', _uid)) = 1 THEN 1 ELSE 0 END is_readed,
+    CASE WHEN JSON_LENGTH(c.metadata, '$._seen_') >= JSON_LENGTH(c.metadata, '$._delivered_')
+      THEN 1 ELSE 0 END is_seen,
+    IFNULL(read_json_object(c.metadata, 'message_type'), 'chat') message_type,
+    read_json_object(c.metadata, 'call_status') call_status
+  FROM (
+    SELECT sys_id FROM channel c
+    WHERE c.file_thread_id = _file_thread_id
+      AND NOT EXISTS( SELECT 1 FROM delete_channel WHERE uid = _uid AND ref_sys_id = c.sys_id)
+    ORDER BY c.sys_id DESC LIMIT _offset, _range
+  ) s
+  INNER JOIN channel c ON c.sys_id = s.sys_id
+  LEFT JOIN yp.drumate d ON c.author_id = d.id
+  LEFT JOIN yp.dmz_user du ON c.author_id = du.id
+  ORDER BY c.sys_id DESC;
+END $
+
+DELIMITER ;

--- a/hub/procedures/channel/channel_file_thread_post_touch.sql
+++ b/hub/procedures/channel/channel_file_thread_post_touch.sql
@@ -1,0 +1,39 @@
+DELIMITER $
+
+-- =========================================================
+-- channel_file_thread_post_touch
+-- Refresh the thread summary after a child message is posted or deleted.
+--   _delta = +1 on post, -1 on delete (floored at 0).
+-- Also writes the summary onto the root system card's metadata so the folder
+-- card can hydrate reply_count / last_message_id / mtime without an extra join.
+-- =========================================================
+DROP PROCEDURE IF EXISTS `channel_file_thread_post_touch`$
+CREATE PROCEDURE `channel_file_thread_post_touch`(
+  IN _file_thread_id VARCHAR(16),
+  IN _last_message_id VARCHAR(16),
+  IN _delta INT
+)
+BEGIN
+  DECLARE _now INT(11) UNSIGNED;
+  DECLARE _rc INT DEFAULT 0;
+  SET _now = UNIX_TIMESTAMP();
+
+  UPDATE file_thread
+    SET last_message_id = _last_message_id,
+        reply_count = GREATEST(0, CAST(reply_count AS SIGNED) + _delta),
+        mtime = _now
+    WHERE root_message_id = _file_thread_id AND status = 'active';
+
+  SELECT reply_count INTO _rc
+    FROM file_thread WHERE root_message_id = _file_thread_id AND status = 'active' LIMIT 1;
+
+  UPDATE channel SET metadata = JSON_SET(
+      IFNULL(metadata, '{}'),
+      '$._file_thread_reply_count', _rc,
+      '$._file_thread_last_message_id', _last_message_id,
+      '$._file_thread_mtime', _now
+    )
+    WHERE message_id = _file_thread_id;
+END $
+
+DELIMITER ;

--- a/hub/procedures/channel/channel_file_thread_read_messages.sql
+++ b/hub/procedures/channel/channel_file_thread_read_messages.sql
@@ -1,0 +1,40 @@
+DELIMITER $
+
+-- =========================================================
+-- channel_file_thread_read_messages
+-- Mark a single file thread seen up to _msg_id. Scoped to file_thread_id, so
+-- acknowledging a file chat never clears unread state for sibling folder or
+-- workspace messages (and vice versa via channel_read_messages).
+-- =========================================================
+DROP PROCEDURE IF EXISTS `channel_file_thread_read_messages`$
+CREATE PROCEDURE `channel_file_thread_read_messages`(
+  IN _msg_id VARCHAR(16),
+  IN _uid VARCHAR(16),
+  IN _file_thread_id VARCHAR(16)
+)
+BEGIN
+  DECLARE _sys_id INTEGER DEFAULT 0;
+
+  SELECT sys_id INTO _sys_id
+    FROM channel
+    WHERE message_id = _msg_id AND file_thread_id = _file_thread_id;
+
+  IF _sys_id > 0 THEN
+    UPDATE channel SET metadata = JSON_SET(metadata, CONCAT('$._seen_.', _uid), UNIX_TIMESTAMP())
+    WHERE file_thread_id = _file_thread_id
+      AND sys_id <= _sys_id
+      AND JSON_EXISTS(metadata, CONCAT('$._seen_.', _uid)) = 0;
+  END IF;
+
+  SELECT
+    sys_id,
+    message_id,
+    thread_id,
+    file_thread_id,
+    metadata,
+    CASE WHEN JSON_EXISTS(metadata, CONCAT('$._seen_.', _uid)) = 1 THEN 1 ELSE 0 END is_readed,
+    CASE WHEN JSON_LENGTH(metadata, '$._seen_') >= JSON_LENGTH(metadata, '$._delivered_') THEN 1 ELSE 0 END is_seen
+  FROM channel WHERE message_id = _msg_id AND file_thread_id = _file_thread_id;
+END $
+
+DELIMITER ;

--- a/hub/procedures/channel/channel_file_thread_remove_root.sql
+++ b/hub/procedures/channel/channel_file_thread_remove_root.sql
@@ -1,0 +1,26 @@
+DELIMITER $
+
+-- =========================================================
+-- channel_file_thread_remove_root
+-- Rollback an orphan thread: soft-delete the file_thread row and remove the
+-- folder-visible root card. Called by the service ONLY when the first child
+-- message fails after channel_file_thread_ensure_root reserved a new thread,
+-- and BEFORE any broadcast. Restricted to the creator so a concurrent sender
+-- cannot drop another user's just-created thread.
+-- =========================================================
+DROP PROCEDURE IF EXISTS `channel_file_thread_remove_root`$
+CREATE PROCEDURE `channel_file_thread_remove_root`(
+  IN _file_thread_id VARCHAR(16),
+  IN _uid VARCHAR(16)
+)
+BEGIN
+  UPDATE file_thread
+    SET status = 'deleted', mtime = UNIX_TIMESTAMP()
+    WHERE root_message_id = _file_thread_id AND created_by = _uid;
+
+  -- Same creator guard as the soft-delete above: the root card's author_id is
+  -- the thread creator, so a concurrent sender cannot drop another user's card.
+  DELETE FROM channel WHERE message_id = _file_thread_id AND author_id = _uid;
+END $
+
+DELIMITER ;

--- a/hub/procedures/channel/channel_list_messages.sql
+++ b/hub/procedures/channel/channel_list_messages.sql
@@ -7,54 +7,61 @@ CREATE PROCEDURE `channel_list_messages`(
   IN _page    TINYINT(4)
 )
 BEGIN
-  DECLARE _recipient_db VARCHAR(255); 
+  DECLARE _recipient_db VARCHAR(255);
   DECLARE _msg_id VARCHAR(16);
   DECLARE _timestamp int(11) unsigned;
   DECLARE _range bigint;
   DECLARE _offset bigint;
   DECLARE _ref_sys_id int(11) unsigned default 0 ;
   DECLARE _old_ref_sys_id int(11) unsigned default 0 ;
-  CALL pageToLimits(_page, _offset, _range);  
-  SELECT  sys_id FROM  (SELECT sys_id  FROM channel c 
-  WHERE NOT EXISTS( SELECT 1 FROM delete_channel WHERE uid =_uid AND ref_sys_id = c.sys_id) 
-  ORDER BY c.sys_id  DESC  LIMIT _offset, _range) a ORDER BY sys_id  DESC LIMIT 1 INTO _ref_sys_id; 
+  CALL pageToLimits(_page, _offset, _range);
+  -- File-thread child messages never appear in the normal (workspace/folder)
+  -- chat list; they have their own list path (channel_file_thread_list_messages).
+  SELECT  sys_id FROM  (SELECT sys_id  FROM channel c
+  WHERE NOT EXISTS( SELECT 1 FROM delete_channel WHERE uid =_uid AND ref_sys_id = c.sys_id)
+  AND c.file_thread_id IS NULL
+  ORDER BY c.sys_id  DESC  LIMIT _offset, _range) a ORDER BY sys_id  DESC LIMIT 1 INTO _ref_sys_id;
   SELECT ref_sys_id FROM read_channel WHERE  uid = _uid INTO _old_ref_sys_id;
-  IF ( _ref_sys_id > IFNULL(_old_ref_sys_id,0)) THEN  
+  IF ( _ref_sys_id > IFNULL(_old_ref_sys_id,0)) THEN
      UPDATE channel SET  metadata = JSON_SET(metadata,CONCAT("$._seen_.", _uid), UNIX_TIMESTAMP())
-     WHERE sys_id <= _ref_sys_id   AND 
+     WHERE sys_id <= _ref_sys_id   AND
+     file_thread_id IS NULL AND
      JSON_EXISTS(metadata, CONCAT("$._seen_.", _uid))= 0;
-    INSERT INTO read_channel(uid,ref_sys_id,ctime) SELECT _uid,_ref_sys_id,UNIX_TIMESTAMP() 
+    INSERT INTO read_channel(uid,ref_sys_id,ctime) SELECT _uid,_ref_sys_id,UNIX_TIMESTAMP()
     ON DUPLICATE KEY UPDATE ref_sys_id= _ref_sys_id , ctime =UNIX_TIMESTAMP();
-  END IF; 
-  SELECT 
+  END IF;
+  SELECT
     _page as `page`,
     c.sys_id,
-    c.author_id,  
-    c.message,   
-    c.message_id, 
-    c.thread_id, 
+    c.author_id,
+    c.message,
+    c.message_id,
+    c.thread_id,
+    c.file_thread_id,
     c.is_forward,
     c.mention_ids,
-    c.attachment, 
-    CASE WHEN LTRIM(RTRIM(c.attachment))='' OR  c.attachment IS NULL THEN 0 ELSE 1 END is_attachment, 
-    c.status,     
-    c.ctime,      
+    c.attachment,
+    CASE WHEN LTRIM(RTRIM(c.attachment))='' OR  c.attachment IS NULL THEN 0 ELSE 1 END is_attachment,
+    c.status,
+    c.ctime,
     c.metadata,
+    IFNULL(read_json_object(c.metadata, 'message_type'), 'chat') message_type,
     COALESCE(d.firstname, du.name, '') firstname,
     COALESCE(d.lastname, '') lastname,
     COALESCE(CONCAT(d.firstname, ' ', d.lastname), du.name, '') fullname,
-    CASE WHEN _old_ref_sys_id  <  c.sys_id THEN 1 ELSE 0 END is_notify,  
+    CASE WHEN _old_ref_sys_id  <  c.sys_id THEN 1 ELSE 0 END is_notify,
     CASE WHEN JSON_EXISTS(metadata, CONCAT("$._seen_.", _uid))= 1 THEN 1 ELSE 0 END is_readed,
-    CASE WHEN JSON_LENGTH(metadata , '$._seen_')  >=  JSON_LENGTH(metadata , '$._delivered_') 
+    CASE WHEN JSON_LENGTH(metadata , '$._seen_')  >=  JSON_LENGTH(metadata , '$._delivered_')
     THEN  1 ELSE 0 END is_seen
-  FROM 
-    (SELECT sys_id FROM channel c  
-      WHERE NOT EXISTS( SELECT 1 FROM delete_channel WHERE uid =_uid AND ref_sys_id = c.sys_id) 
+  FROM
+    (SELECT sys_id FROM channel c
+      WHERE NOT EXISTS( SELECT 1 FROM delete_channel WHERE uid =_uid AND ref_sys_id = c.sys_id)
+      AND c.file_thread_id IS NULL
     ORDER BY c.sys_id  DESC LIMIT _offset, _range) s
   INNER JOIN channel c  on c.sys_id = s.sys_id
   LEFT JOIN yp.drumate d ON c.author_id = d.id
   LEFT JOIN yp.dmz_user du ON c.author_id = du.id
- 
+
   ORDER BY c.sys_id DESC;
 END$
 DELIMITER ;

--- a/hub/procedures/channel/channel_post_message.sql
+++ b/hub/procedures/channel/channel_post_message.sql
@@ -6,8 +6,9 @@ CREATE PROCEDURE `channel_post_message`(
   IN _message text
 )
 BEGIN
- DECLARE _hub_id VARCHAR(16) CHARACTER SET ascii;  
+ DECLARE _hub_id VARCHAR(16) CHARACTER SET ascii;
  DECLARE _thread_id  VARCHAR(16) CHARACTER SET ascii;
+ DECLARE _file_thread_id VARCHAR(16) CHARACTER SET ascii;
  DECLARE _forward_message_id VARCHAR(16) CHARACTER SET ascii;
  DECLARE _attachment JSON;
  DECLARE _metadata JSON;
@@ -44,8 +45,9 @@ DECLARE _is_duplicate INTEGER DEFAULT 0;
   SELECT JSON_VALUE(_in, "$.entity_id") INTO _entity_id;
   SELECT JSON_VALUE(_in, "$.ticket_id") INTO _ticket_id; 
 
-  SELECT JSON_VALUE(_in, "$.thread_id") INTO _thread_id; 
-  SELECT JSON_VALUE(_in, "$.forward_message_id") INTO _forward_message_id; 
+  SELECT JSON_VALUE(_in, "$.thread_id") INTO _thread_id;
+  SELECT JSON_VALUE(_in, "$.file_thread_id") INTO _file_thread_id;
+  SELECT JSON_VALUE(_in, "$.forward_message_id") INTO _forward_message_id;
   SELECT JSON_QUERY(_in, "$.attachment") INTO _attachment; 
   SELECT JSON_VALUE(_in, "$.message_id") INTO _message_id;
   SELECT JSON_QUERY(_in, "$.metadata") INTO _metadata;
@@ -59,12 +61,12 @@ DECLARE _is_duplicate INTEGER DEFAULT 0;
   END IF ;
   
   IF _type = 'hub' THEN
-    INSERT INTO channel (message_id,author_id,message,thread_id,ctime,attachment,mention_ids,metadata)
-    SELECT _message_id,_author_id,_message,_thread_id,_ctime,_attachment,_mention_ids,_metadata
+    INSERT INTO channel (message_id,author_id,message,thread_id,file_thread_id,ctime,attachment,mention_ids,metadata)
+    SELECT _message_id,_author_id,_message,_thread_id,_file_thread_id,_ctime,_attachment,_mention_ids,_metadata
       ON DUPLICATE KEY UPDATE  message_id =_message_id;
   ELSE
-    INSERT INTO channel (message_id,author_id,message,thread_id,ctime,attachment,mention_ids,metadata)
-    SELECT _message_id,_author_id,_message,_thread_id,_ctime,_attachment,_mention_ids,_metadata
+    INSERT INTO channel (message_id,author_id,message,thread_id,file_thread_id,ctime,attachment,mention_ids,metadata)
+    SELECT _message_id,_author_id,_message,_thread_id,_file_thread_id,_ctime,_attachment,_mention_ids,_metadata
      ON DUPLICATE KEY UPDATE  message_id =_message_id;
   END IF ;
 
@@ -114,9 +116,13 @@ DECLARE _is_duplicate INTEGER DEFAULT 0;
         CLOSE db_cursor;
       END; 
  
-    INSERT INTO read_channel(uid,ref_sys_id,ctime) 
-    SELECT _author_id,_ref_sys_id,_ctime
-    ON DUPLICATE KEY UPDATE ref_sys_id= _ref_sys_id , ctime =_ctime;
+    -- File-thread posts must NOT advance the author's hub-wide read pointer
+    -- (would ack sibling folder/workspace messages). Only normal chat does.
+    IF _file_thread_id IS NULL THEN
+      INSERT INTO read_channel(uid,ref_sys_id,ctime)
+      SELECT _author_id,_ref_sys_id,_ctime
+      ON DUPLICATE KEY UPDATE ref_sys_id= _ref_sys_id , ctime =_ctime;
+    END IF;
 
     SELECT ticket_id FROM map_ticket WHERE message_id = _message_id INTO _ticket_id; 
     IF  _ticket_id IS NOT NULL THEN 
@@ -130,10 +136,14 @@ DECLARE _is_duplicate INTEGER DEFAULT 0;
       ON DUPLICATE KEY UPDATE ref_sys_id= _ref_sys_id , ctime =UNIX_TIMESTAMP() ;
 
       UPDATE yp.ticket SET last_sys_id =  _ref_sys_id WHERE  ticket_id =_ticket_id AND _is_duplicate = 0;
-    ELSE 
-      UPDATE channel SET  metadata = JSON_SET(metadata,CONCAT("$._seen_.", _author_id), _ctime)
-      WHERE sys_id <= _ref_sys_id  AND 
-      JSON_EXISTS(metadata, CONCAT("$._seen_.", _author_id))= 0 AND _is_duplicate = 0;  
+    ELSE
+      -- Broad "mark seen up to here" is for normal chat only. File-thread
+      -- children keep their own per-thread read state (channel_file_thread_*).
+      IF _file_thread_id IS NULL THEN
+        UPDATE channel SET  metadata = JSON_SET(metadata,CONCAT("$._seen_.", _author_id), _ctime)
+        WHERE sys_id <= _ref_sys_id  AND
+        JSON_EXISTS(metadata, CONCAT("$._seen_.", _author_id))= 0 AND _is_duplicate = 0;
+      END IF;
     END IF;
 
     SELECT id FROM yp.entity WHERE db_name= DATABASE() INTO _hub_id; 
@@ -142,15 +152,16 @@ DECLARE _is_duplicate INTEGER DEFAULT 0;
       c.author_id,  
       c.message,   
       c.message_id, 
-      c.thread_id,  
+      c.thread_id,
+      c.file_thread_id,
       c.is_forward,
       c.attachment,
       c.mention_ids,
       c.status,
-      c.ctime,      
-      c.metadata,  
+      c.ctime,
+      c.metadata,
       CASE WHEN JSON_EXISTS(c.metadata, CONCAT("$._seen_.", _author_id))= 1 THEN 1 ELSE 0 END is_readed,
-      CASE WHEN JSON_LENGTH(c.metadata , '$._seen_')  >=  JSON_LENGTH(c.metadata , '$._delivered_') 
+      CASE WHEN JSON_LENGTH(c.metadata , '$._seen_')  >=  JSON_LENGTH(c.metadata , '$._delivered_')
       THEN  1 ELSE 0 END is_seen,
       IFNULL(read_json_object(c.metadata, "message_type"),'chat')   message_type,
       CASE WHEN  t.message_id IS NOT NULL THEN 1 ELSE 0 END is_ticket,
@@ -171,6 +182,7 @@ DECLARE _is_duplicate INTEGER DEFAULT 0;
       message,
       message_id,
       thread_id,
+      file_thread_id,
       is_forward,
       attachment,
       mention_ids,

--- a/hub/procedures/channel/channel_read_messages.sql
+++ b/hub/procedures/channel/channel_read_messages.sql
@@ -10,8 +10,13 @@ BEGIN
 
   SELECT sys_id FROM channel WHERE message_id = _msg_id INTO _sys_id;
 
+  -- Normal read path marks only normal (non-file-thread) messages seen.
+  -- File-thread children keep their own per-thread read state via
+  -- channel_file_thread_read_messages, so reading the workspace/folder chat
+  -- never clears a sibling file thread's unread state.
   UPDATE channel SET metadata = JSON_SET(metadata, CONCAT("$._seen_.", _uid), UNIX_TIMESTAMP())
   WHERE sys_id <= _sys_id
+  AND file_thread_id IS NULL
   AND JSON_EXISTS(metadata, CONCAT("$._seen_.", _uid)) = 0;
 
   SELECT
@@ -20,6 +25,7 @@ BEGIN
     message,
     message_id,
     thread_id,
+    file_thread_id,
     attachment,
     status,
     ctime,

--- a/hub/tables/channel.sql
+++ b/hub/tables/channel.sql
@@ -5,6 +5,7 @@ CREATE TABLE IF NOT EXISTS `channel` (
   `message` mediumtext DEFAULT NULL,
   `message_id` varchar(16) CHARACTER SET ascii COLLATE ascii_general_ci DEFAULT NULL,
   `thread_id` varchar(16) CHARACTER SET ascii COLLATE ascii_general_ci DEFAULT NULL,
+  `file_thread_id` varchar(16) CHARACTER SET ascii COLLATE ascii_general_ci DEFAULT NULL,
   `attachment` longtext DEFAULT NULL CHECK (json_valid(`attachment`)),
   `is_forward` tinyint(1) DEFAULT 0,
   `mention_ids` JSON NULL,
@@ -12,5 +13,6 @@ CREATE TABLE IF NOT EXISTS `channel` (
   `ctime` int(11) NOT NULL,
   `metadata`    mediumtext DEFAULT NULL,
   PRIMARY KEY (`sys_id`),
-  UNIQUE KEY `message_id` (`message_id`)
+  UNIQUE KEY `message_id` (`message_id`),
+  KEY `channel_file_thread_idx` (`file_thread_id`, `sys_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;

--- a/hub/tables/file_thread.sql
+++ b/hub/tables/file_thread.sql
@@ -1,0 +1,21 @@
+-- One chat thread per file in a hub.
+-- file_thread_id exposed to UI == root_message_id (the message_id of the
+-- folder-visible "file.thread" system card in `channel`).
+-- folder_nid is CREATION CONTEXT only; current folder membership follows
+-- media.parent_id (see channel_file_thread_list_by_folder).
+CREATE TABLE IF NOT EXISTS `file_thread` (
+  `sys_id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `file_nid` varchar(16) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL,
+  `folder_nid` varchar(16) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL,
+  `root_message_id` varchar(16) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL,
+  `created_by` varchar(16) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL,
+  `last_message_id` varchar(16) CHARACTER SET ascii COLLATE ascii_general_ci DEFAULT NULL,
+  `reply_count` int(11) unsigned NOT NULL DEFAULT 0,
+  `ctime` int(11) NOT NULL,
+  `mtime` int(11) NOT NULL,
+  `status` enum('active','deleted') NOT NULL DEFAULT 'active',
+  PRIMARY KEY (`sys_id`),
+  UNIQUE KEY `file_thread_file_uidx` (`file_nid`),
+  UNIQUE KEY `file_thread_root_uidx` (`root_message_id`),
+  KEY `file_thread_folder_idx` (`folder_nid`, `status`, `mtime`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;

--- a/patches/changelog.txt
+++ b/patches/changelog.txt
@@ -1,3 +1,10 @@
+2026-06-27
+  hub/procedures/channel/channel_export_messages.sql
+  hub/procedures/channel/channel_export_file_thread_messages.sql
+  hub/procedures/channel/channel_export_file_thread_list.sql
+  hub/procedures/channel/channel_export_count.sql
+  hub/procedures/channel/channel_export_file_thread_count.sql
+
 2026-06-22
   common/procedures/permission/permission_get_direct.sql
   yellow_page/procedures/session/clear_session_priv_ceiling.sql

--- a/patches/manifest.txt
+++ b/patches/manifest.txt
@@ -47,3 +47,17 @@
   yellow_page/procedures/utils/disk_limit.sql
   yellow_page/procedures/utils/disk_free.sql
   yellow_page/procedures/directory/my_disk_limit.sql
+  hub/tables/channel.sql
+  hub/tables/file_thread.sql
+  hub/patches/2026-06-26-channel-file-thread.sql
+  hub/procedures/channel/channel_post_message.sql
+  hub/procedures/channel/channel_list_messages.sql
+  hub/procedures/channel/channel_read_messages.sql
+  hub/procedures/channel/channel_file_thread_info.sql
+  hub/procedures/channel/channel_file_thread_ensure_root.sql
+  hub/procedures/channel/channel_file_thread_post_touch.sql
+  hub/procedures/channel/channel_file_thread_list_by_folder.sql
+  hub/procedures/channel/channel_file_thread_list_messages.sql
+  hub/procedures/channel/channel_file_thread_read_messages.sql
+  hub/procedures/channel/channel_file_thread_remove_root.sql
+  drumate/procedures/notification/notification_center_next.sql

--- a/patches/manifest.txt
+++ b/patches/manifest.txt
@@ -66,3 +66,4 @@
   hub/procedures/channel/channel_export_file_thread_list.sql
   hub/procedures/channel/channel_export_count.sql
   hub/procedures/channel/channel_export_file_thread_count.sql
+  common/procedures/channel/channel_search_scoped.sql

--- a/patches/manifest.txt
+++ b/patches/manifest.txt
@@ -61,3 +61,8 @@
   hub/procedures/channel/channel_file_thread_read_messages.sql
   hub/procedures/channel/channel_file_thread_remove_root.sql
   drumate/procedures/notification/notification_center_next.sql
+  hub/procedures/channel/channel_export_messages.sql
+  hub/procedures/channel/channel_export_file_thread_messages.sql
+  hub/procedures/channel/channel_export_file_thread_list.sql
+  hub/procedures/channel/channel_export_count.sql
+  hub/procedures/channel/channel_export_file_thread_count.sql


### PR DESCRIPTION
Ports the per-file chat-thread schema (file_thread table + file_thread_id, 7 file_thread procs, file-thread-aware list/post/read + notification rollup) and the conversation-scoped message-search proc (channel_search_scoped). Tested on aaron stage DBs. Target: test.