### PR TITLE
Test → Preview: schemas (task-assigned notif + retention + survey + admin-console)

### DIFF
--- a/common/procedures/mfs/versioning/file_version_delete_old.sql
+++ b/common/procedures/mfs/versioning/file_version_delete_old.sql
@@ -8,7 +8,7 @@ CREATE PROCEDURE `file_version_delete_old`(
 BEGIN
   DELETE FROM file_version
   WHERE is_active = 0
-    AND (_nid IS NULL OR nid = _nid);
+    AND (_nid IS NULL OR _nid = '' OR nid = _nid);
 
   SELECT ROW_COUNT() AS deleted;
 END$

--- a/common/procedures/mfs/versioning/file_version_purge_expired.sql
+++ b/common/procedures/mfs/versioning/file_version_purge_expired.sql
@@ -1,0 +1,21 @@
+DELIMITER $
+
+DROP PROCEDURE IF EXISTS `file_version_purge_expired`$
+CREATE PROCEDURE `file_version_purge_expired`(
+  IN _days INT
+)
+BEGIN
+  -- Enforce the org retention window: drop OLD (is_active=0) file versions whose
+  -- ctime is older than _days. The active version (is_active=1) is never touched.
+  -- DB-only, matching the existing file_version_delete_old admin action (on-disk
+  -- version blobs are reclaimed by the node-level mfs_purge / remove_node path).
+  DECLARE _cutoff INT DEFAULT 0;
+  SET _cutoff = UNIX_TIMESTAMP() - (_days * 86400);
+
+  DELETE FROM file_version
+  WHERE is_active = 0 AND ctime < _cutoff;
+
+  SELECT ROW_COUNT() AS purged;
+END$
+
+DELIMITER ;

--- a/common/procedures/mfs/versioning/get_hub_version_size.sql
+++ b/common/procedures/mfs/versioning/get_hub_version_size.sql
@@ -1,0 +1,15 @@
+DELIMITER $
+
+DROP PROCEDURE IF EXISTS `get_hub_version_size`$
+CREATE PROCEDURE `get_hub_version_size`()
+BEGIN
+  -- Per-hub versioning footprint, split by active vs history. Summed across the
+  -- org's hubs by versionRetentionWorker to populate the "Versioning Impact"
+  -- card (history_bytes cached into organisation.metadata).
+  SELECT
+    COALESCE(SUM(IF(is_active = 0, filesize, 0)), 0) AS history_bytes,
+    COALESCE(SUM(IF(is_active = 1, filesize, 0)), 0) AS active_bytes
+  FROM file_version;
+END$
+
+DELIMITER ;

--- a/hub/procedures/admin/hub_list_folders.sql
+++ b/hub/procedures/admin/hub_list_folders.sql
@@ -3,7 +3,8 @@ DELIMITER $
 DROP PROCEDURE IF EXISTS `hub_list_folders`$
 CREATE PROCEDURE `hub_list_folders`(
   IN _node_id VARCHAR(16) CHARACTER SET ascii,
-  IN _page    TINYINT(4)
+  IN _page    TINYINT(4),
+  IN _query   VARCHAR(255) CHARACTER SET utf8mb4
 )
 BEGIN
   -- Lists folder/hub children of a node for the admin Permissions tab
@@ -15,10 +16,14 @@ BEGIN
   -- matches.
   --
   -- _node_id NULL means "list children of the hub root".
+  -- _query (when non-empty) searches user_filename across the whole hub
+  -- instead of scoping to _node_id's direct children.
 
-  DECLARE _range  BIGINT;
-  DECLARE _offset BIGINT;
+  DECLARE _range   BIGINT;
+  DECLARE _offset  BIGINT;
   DECLARE _home_id VARCHAR(16) CHARACTER SET ascii;
+  DECLARE _has_q   TINYINT(1) DEFAULT 0;
+  DECLARE _like    VARCHAR(520) CHARACTER SET utf8mb4;
 
   CALL pageToLimits(_page, _offset, _range);
 
@@ -29,6 +34,17 @@ BEGIN
   -- otherwise WHERE parent_id = '' matches nothing and the FE gets [].
   IF _node_id IS NULL OR _node_id = '0' OR _node_id = '' THEN
     SET _node_id = _home_id;
+  END IF;
+
+  IF _query IS NOT NULL AND _query <> '' THEN
+    SET _has_q = 1;
+    -- Escape LIKE wildcards in the user-supplied query so '%' / '_'
+    -- are matched literally; '|' is the ESCAPE char below.
+    SET _like = CONCAT(
+      '%',
+      REPLACE(REPLACE(REPLACE(_query, '|', '||'), '%', '|%'), '_', '|_'),
+      '%'
+    );
   END IF;
 
   SELECT
@@ -48,7 +64,8 @@ BEGIN
     m.extension     AS ext,
     m.metadata      AS metadata
   FROM media m
-  WHERE m.parent_id = _node_id
+  WHERE (_has_q = 1 OR m.parent_id = _node_id)
+    AND (_has_q = 0 OR m.user_filename LIKE _like ESCAPE '|')
     AND m.category IN ('folder', 'hub')
     AND m.status NOT IN ('hidden', 'deleted')
     AND m.file_path NOT REGEXP '^/__(chat|trash|upload)__'

--- a/hub/procedures/admin/hub_member_remove.sql
+++ b/hub/procedures/admin/hub_member_remove.sql
@@ -6,9 +6,36 @@ CREATE PROCEDURE `hub_member_remove`(
   IN _removed_by VARCHAR(16)
 )
 BEGIN
+  DECLARE _hid VARCHAR(16);
+  DECLARE _member_db VARCHAR(80);
+
+  -- Hub side (current db = hub_db): drop this member's hub-level grant.
   DELETE FROM permission
   WHERE entity_id = _uid
     AND resource_id = '*';
+
+  -- Member side: member_list_workspaces reads `<member_db>`.permission
+  -- (resource_id = this hub's id) and the desk node lives in `<member_db>`.media
+  -- (id = hub id, created by join_hub). Deleting only the hub-side '*' row leaves
+  -- the removed member still listed in the admin-console workspace list — mirror
+  -- remove_member's member-side cleanup so removal is reflected everywhere.
+  SELECT id FROM yp.entity WHERE db_name = database() INTO _hid;
+  SELECT db_name FROM yp.entity WHERE id = _uid INTO _member_db;
+
+  IF _member_db IS NOT NULL AND _hid IS NOT NULL THEN
+    SET @s = CONCAT('DELETE FROM `', _member_db,
+      '`.permission WHERE resource_id = ', QUOTE(_hid),
+      ' AND entity_id = ', QUOTE(_uid));
+    PREPARE stmt FROM @s;
+    EXECUTE stmt;
+    DEALLOCATE PREPARE stmt;
+
+    SET @s = CONCAT('DELETE FROM `', _member_db,
+      '`.media WHERE id = ', QUOTE(_hid));
+    PREPARE stmt FROM @s;
+    EXECUTE stmt;
+    DEALLOCATE PREPARE stmt;
+  END IF;
 
   CALL hub_add_action_log(
     _removed_by,

--- a/patches/changelog.txt
+++ b/patches/changelog.txt
@@ -1,6 +1,12 @@
 2026-07-02
   yellow_page/procedures/adminpannel/member_save_workspace_roles.sql
   hub/procedures/admin/hub_member_remove.sql
+  yellow_page/procedures/organization/organisation_get_retention.sql
+  yellow_page/procedures/organization/organisation_set_retention.sql
+  yellow_page/procedures/organization/organisation_list_retention.sql
+  yellow_page/procedures/organization/organisation_cache_version_history.sql
+  common/procedures/mfs/versioning/file_version_purge_expired.sql
+  common/procedures/mfs/versioning/get_hub_version_size.sql
 
 2026-06-30
   drumate/procedures/activity_get_feed_all.sql

--- a/patches/changelog.txt
+++ b/patches/changelog.txt
@@ -8,6 +8,7 @@
   common/procedures/mfs/versioning/file_version_purge_expired.sql
   common/procedures/mfs/versioning/get_hub_version_size.sql
   yellow_page/procedures/contact/contact_log_activity.sql
+  yellow_page/procedures/contact/contact_task_assigned_unread.sql
 
 2026-06-30
   drumate/procedures/activity_get_feed_all.sql

--- a/patches/changelog.txt
+++ b/patches/changelog.txt
@@ -1,3 +1,6 @@
+2026-07-02
+  yellow_page/procedures/adminpannel/member_save_workspace_roles.sql
+
 2026-06-30
   drumate/procedures/activity_get_feed_all.sql
 

--- a/patches/changelog.txt
+++ b/patches/changelog.txt
@@ -7,6 +7,7 @@
   yellow_page/procedures/organization/organisation_cache_version_history.sql
   common/procedures/mfs/versioning/file_version_purge_expired.sql
   common/procedures/mfs/versioning/get_hub_version_size.sql
+  yellow_page/procedures/contact/contact_log_activity.sql
 
 2026-06-30
   drumate/procedures/activity_get_feed_all.sql

--- a/patches/changelog.txt
+++ b/patches/changelog.txt
@@ -1,5 +1,6 @@
 2026-07-02
   yellow_page/procedures/adminpannel/member_save_workspace_roles.sql
+  hub/procedures/admin/hub_member_remove.sql
 
 2026-06-30
   drumate/procedures/activity_get_feed_all.sql

--- a/patches/manifest.txt
+++ b/patches/manifest.txt
@@ -1,4 +1,5 @@
 
+  yellow_page/procedures/adminpannel/member_save_workspace_roles.sql
   yellow_page/procedures/activity_publish.sql
   yellow_page/tables/contact_activity.sql
   hub/procedures/members/hub_get_members_by_type.sql

--- a/patches/manifest.txt
+++ b/patches/manifest.txt
@@ -1,5 +1,6 @@
 
   yellow_page/procedures/adminpannel/member_save_workspace_roles.sql
+  hub/procedures/admin/hub_member_remove.sql
   yellow_page/procedures/activity_publish.sql
   yellow_page/tables/contact_activity.sql
   hub/procedures/members/hub_get_members_by_type.sql

--- a/patches/manifest.txt
+++ b/patches/manifest.txt
@@ -55,3 +55,5 @@
   yellow_page/procedures/utils/disk_limit.sql
   yellow_page/procedures/utils/disk_free.sql
   yellow_page/procedures/directory/my_disk_limit.sql
+  yellow_page/tables/survey_response.sql
+  yellow_page/procedures/survey/survey_upsert.sql

--- a/patches/manifest.txt
+++ b/patches/manifest.txt
@@ -1,6 +1,12 @@
 
   yellow_page/procedures/adminpannel/member_save_workspace_roles.sql
   hub/procedures/admin/hub_member_remove.sql
+  yellow_page/procedures/organization/organisation_get_retention.sql
+  yellow_page/procedures/organization/organisation_set_retention.sql
+  yellow_page/procedures/organization/organisation_list_retention.sql
+  yellow_page/procedures/organization/organisation_cache_version_history.sql
+  common/procedures/mfs/versioning/file_version_purge_expired.sql
+  common/procedures/mfs/versioning/get_hub_version_size.sql
   yellow_page/procedures/activity_publish.sql
   yellow_page/tables/contact_activity.sql
   hub/procedures/members/hub_get_members_by_type.sql

--- a/yellow_page/procedures/adminpannel/member_save_workspace_roles.sql
+++ b/yellow_page/procedures/adminpannel/member_save_workspace_roles.sql
@@ -9,7 +9,10 @@ CREATE PROCEDURE `member_save_workspace_roles`(
 BEGIN
   DECLARE _hub_id VARCHAR(16);
   DECLARE _priv_val TINYINT(4) UNSIGNED;
+  DECLARE _ui_priv  TINYINT(4) UNSIGNED;
   DECLARE _hub_db VARCHAR(80);
+  DECLARE _member_db VARCHAR(80);
+  DECLARE _ts INT(11) DEFAULT 0;
   DECLARE _stmt TEXT;
   DECLARE done INT DEFAULT FALSE;
 
@@ -24,16 +27,23 @@ BEGIN
     ) AS jt;
   DECLARE CONTINUE HANDLER FOR NOT FOUND SET done = TRUE;
 
+  SELECT UNIX_TIMESTAMP() INTO _ts;
+  -- The member owns the workspace-list rows. member_list_workspaces reads
+  -- `<member_db>`.permission (resource_id = hub_id), NOT the hub-side '*' row —
+  -- so a grant that only touches the hub side never shows up in the list.
+  SELECT db_name INTO _member_db FROM yp.entity WHERE id = _uid;
+
   OPEN cur;
   assign_loop: LOOP
     FETCH cur INTO _hub_id, _priv_val;
     IF done THEN LEAVE assign_loop; END IF;
 
-    SELECT db_name INTO _hub_db
-    FROM yp.entity
-    WHERE id = _hub_id;
+    SELECT db_name INTO _hub_db FROM yp.entity WHERE id = _hub_id;
 
-    IF _hub_db IS NOT NULL THEN
+    IF _hub_db IS NOT NULL AND _member_db IS NOT NULL THEN
+
+      -- (1) Hub side (resource_id='*'). Keep permission_grant so its
+      -- orphaned-hub guard (must keep >=1 owner) still protects the hub.
       -- permission_grant signature:
       -- (resource_id, entity_id, expiry_time, permission, assign_via, msg)
       SET _stmt = CONCAT(
@@ -48,6 +58,48 @@ BEGIN
       PREPARE s FROM _stmt;
       EXECUTE s;
       DEALLOCATE PREPARE s;
+
+      -- Detect a brand-new membership BEFORE writing the member-side row, so we
+      -- only wire the desk node (join_hub) for newly added workspaces and don't
+      -- clobber an existing shortcut on a permission-only change.
+      SET _stmt = CONCAT(
+        'SELECT COUNT(*) INTO @_ws_exists FROM `', _member_db,
+        '`.permission WHERE resource_id=', QUOTE(_hub_id),
+        ' AND entity_id=', QUOTE(_uid)
+      );
+      PREPARE s FROM _stmt;
+      EXECUTE s;
+      DEALLOCATE PREPARE s;
+
+      -- (2) Member side (resource_id=hub_id) — the row member_list_workspaces
+      -- reads. add_member stores permission = privilege|15 here; mirror it so the
+      -- saved role is reflected in the admin-console workspace list.
+      SELECT _priv_val | 15 INTO _ui_priv;
+      SET _stmt = CONCAT(
+        'REPLACE INTO `', _member_db, '`.permission VALUES(null, ',
+          QUOTE(_hub_id), ', ',
+          QUOTE(_uid), ', ',
+          QUOTE('---'), ', ',
+          '0, ',
+          _ts, ', ',
+          _ts, ', ',
+          _ui_priv, ', ',
+          QUOTE('share'), ')'
+      );
+      PREPARE s FROM _stmt;
+      EXECUTE s;
+      DEALLOCATE PREPARE s;
+
+      -- (3) For a new workspace, mount the hub on the member's desk (idempotent
+      -- REPLACE INTO media). Skipped on permission-only changes to preserve any
+      -- existing shortcut/rename.
+      IF @_ws_exists = 0 THEN
+        SET _stmt = CONCAT('CALL `', _member_db, '`.join_hub(', QUOTE(_hub_id), ')');
+        PREPARE s FROM _stmt;
+        EXECUTE s;
+        DEALLOCATE PREPARE s;
+      END IF;
+
     END IF;
   END LOOP;
   CLOSE cur;

--- a/yellow_page/procedures/contact/contact_log_activity.sql
+++ b/yellow_page/procedures/contact/contact_log_activity.sql
@@ -1,9 +1,10 @@
 -- File: schemas/yellow_page/procedures/contact/contact_log_activity.sql
 -- Purpose: Log contact activity events to yp.contact_activity table.
--- Idempotent for hub_invite_received and invite_received: skips insertion if
--- an undismissed row already exists for the same (uid, target_uid, event) and
--- (for hub invites) same hub_id inside JSON data. Keeps the audit log clean
--- when an inviter re-runs add_contributors or re-invites the same contact.
+-- Idempotent for hub_invite_received, invite_received and task_assigned: skips
+-- insertion if an undismissed row already exists for the same (uid, target_uid,
+-- event) and same scope inside JSON data (hub_id for hub invites, task_id for
+-- task assignments). Keeps the audit log clean when an inviter re-runs
+-- add_contributors, re-invites the same contact, or re-assigns the same task.
 
 DELIMITER $
 
@@ -17,6 +18,7 @@ CREATE PROCEDURE `contact_log_activity`(
 )
 BEGIN
   DECLARE _hub_id VARCHAR(16) CHARACTER SET ascii;
+  DECLARE _task_id VARCHAR(16) CHARACTER SET ascii;
   DECLARE _existing_id BIGINT DEFAULT NULL;
 
   -- Only log if both users exist (skip email-only invites)
@@ -54,6 +56,33 @@ BEGIN
        WHERE uid = _uid
          AND target_uid = _target_uid
          AND event = 'invite_received'
+         AND dismissed_at IS NULL
+       ORDER BY id DESC
+       LIMIT 1;
+
+      IF _existing_id IS NOT NULL THEN
+        UPDATE yp.contact_activity
+           SET timestamp = UNIX_TIMESTAMP(),
+               data = _data
+         WHERE id = _existing_id;
+      ELSE
+        INSERT INTO yp.contact_activity (timestamp, uid, target_uid, event, data)
+        VALUES (UNIX_TIMESTAMP(), _uid, _target_uid, _event, _data);
+      END IF;
+
+    ELSEIF _event = 'task_assigned' THEN
+      -- Dedupe per (assigner, assignee, task). Re-assigning the same person to
+      -- the same task refreshes the existing undismissed row instead of stacking
+      -- new rows. Once the assignee dismisses it, a later re-assignment finds no
+      -- undismissed row and inserts a fresh one (a new notification).
+      SET _task_id = JSON_UNQUOTE(JSON_EXTRACT(_data, '$.task_id'));
+
+      SELECT id INTO _existing_id
+        FROM yp.contact_activity
+       WHERE uid = _uid
+         AND target_uid = _target_uid
+         AND event = 'task_assigned'
+         AND JSON_UNQUOTE(JSON_EXTRACT(data, '$.task_id')) = _task_id
          AND dismissed_at IS NULL
        ORDER BY id DESC
        LIMIT 1;

--- a/yellow_page/procedures/contact/contact_task_assigned_unread.sql
+++ b/yellow_page/procedures/contact/contact_task_assigned_unread.sql
@@ -1,0 +1,50 @@
+-- File: schemas/yellow_page/procedures/contact/contact_task_assigned_unread.sql
+-- Purpose: Return the caller's UNDISMISSED task_assigned activity rows so the
+-- activity panel can merge them into the Unread feed (which otherwise only
+-- carries MFS events, hiding task-assignment notifications under Unread ON).
+-- Columns mirror activity_get_feed_all's contact branch exactly, so a merged
+-- row is indistinguishable from the same row under Unread OFF.
+
+DELIMITER $
+
+DROP PROCEDURE IF EXISTS `contact_task_assigned_unread`$
+
+CREATE PROCEDURE `contact_task_assigned_unread`(
+  IN _user_id VARCHAR(16)
+)
+BEGIN
+  SELECT
+    c.id,
+    c.timestamp,
+    c.uid,
+    c.event,
+    'contact' AS event_type,
+    JSON_OBJECT(
+      'uid', c.uid,
+      'email', d1.email,
+      'fullname', d1.fullname
+    ) AS src,
+    JSON_OBJECT(
+      'uid', c.target_uid,
+      'email', d2.email,
+      'fullname', d2.fullname
+    ) AS dest,
+    c.data,
+    0 AS is_read,
+    d1.firstname,
+    d1.lastname,
+    d1.fullname,
+    NULL AS hub_id,
+    NULL AS hub_db_name
+  FROM yp.contact_activity c
+  LEFT JOIN yp.drumate d1 ON c.uid = d1.id
+  LEFT JOIN yp.drumate d2 ON c.target_uid = d2.id
+  WHERE c.target_uid = _user_id
+    AND c.event = 'task_assigned'
+    AND c.dismissed_at IS NULL
+    AND c.uid <> _user_id
+  ORDER BY c.timestamp DESC
+  LIMIT 50;
+END$
+
+DELIMITER ;

--- a/yellow_page/procedures/organization/organisation_cache_version_history.sql
+++ b/yellow_page/procedures/organization/organisation_cache_version_history.sql
@@ -1,0 +1,20 @@
+DELIMITER $
+
+DROP PROCEDURE IF EXISTS `organisation_cache_version_history`$
+CREATE PROCEDURE `organisation_cache_version_history`(
+  IN _id VARCHAR(16),
+  IN _bytes BIGINT UNSIGNED
+)
+BEGIN
+  -- versionRetentionWorker caches the org-wide old-version footprint here so the
+  -- Storage "Versioning Impact" card can render it without a cross-hub scan on
+  -- every page load. Refreshed each worker run.
+  UPDATE organisation
+  SET metadata = JSON_SET(
+    IF(metadata IS NULL OR metadata = '' OR NOT JSON_VALID(metadata), '{}', metadata),
+    '$.version_history_bytes', _bytes
+  )
+  WHERE id = _id;
+END$
+
+DELIMITER ;

--- a/yellow_page/procedures/organization/organisation_get_retention.sql
+++ b/yellow_page/procedures/organization/organisation_get_retention.sql
@@ -1,0 +1,26 @@
+DELIMITER $
+
+DROP PROCEDURE IF EXISTS `organisation_get_retention`$
+CREATE PROCEDURE `organisation_get_retention`(
+  IN _domain_id INT
+)
+BEGIN
+  -- Reads the org-wide versioning retention policy from organisation.metadata.
+  -- Defaults (30 days, toggles off) when the keys were never written. The
+  -- version_history_bytes value is a cache refreshed by versionRetentionWorker
+  -- for the "Versioning Impact" card (0 until the first worker run).
+  SELECT
+    CAST(COALESCE(JSON_VALUE(m, '$.version_retention_days'),        30) AS UNSIGNED) AS retention_days,
+    CAST(COALESCE(JSON_VALUE(m, '$.version_apply_immediately'),      0) AS UNSIGNED) AS apply_immediately,
+    CAST(COALESCE(JSON_VALUE(m, '$.version_allow_members_view'),     0) AS UNSIGNED) AS allow_members_view,
+    CAST(COALESCE(JSON_VALUE(m, '$.version_allow_editors_restore'),  0) AS UNSIGNED) AS allow_editors_restore,
+    CAST(COALESCE(JSON_VALUE(m, '$.version_history_bytes'),          0) AS UNSIGNED) AS version_history_bytes
+  FROM (
+    SELECT IF(metadata IS NULL OR metadata = '' OR NOT JSON_VALID(metadata), '{}', metadata) AS m
+    FROM organisation
+    WHERE domain_id = _domain_id
+    LIMIT 1
+  ) t;
+END$
+
+DELIMITER ;

--- a/yellow_page/procedures/organization/organisation_list_retention.sql
+++ b/yellow_page/procedures/organization/organisation_list_retention.sql
@@ -1,0 +1,21 @@
+DELIMITER $
+
+DROP PROCEDURE IF EXISTS `organisation_list_retention`$
+CREATE PROCEDURE `organisation_list_retention`()
+BEGIN
+  -- Orgs that EXPLICITLY configured a versioning retention policy. Used by
+  -- versionRetentionWorker to enforce the window only where an admin opted in
+  -- (orgs without the key keep all versions — no surprise auto-purge).
+  SELECT
+    id AS org_id,
+    domain_id,
+    CAST(JSON_VALUE(metadata, '$.version_retention_days') AS UNSIGNED) AS retention_days
+  FROM organisation
+  WHERE metadata IS NOT NULL
+    AND metadata <> ''
+    AND JSON_VALID(metadata)
+    AND JSON_VALUE(metadata, '$.version_retention_days') IS NOT NULL
+    AND domain_id IS NOT NULL;
+END$
+
+DELIMITER ;

--- a/yellow_page/procedures/organization/organisation_set_retention.sql
+++ b/yellow_page/procedures/organization/organisation_set_retention.sql
@@ -1,0 +1,28 @@
+DELIMITER $
+
+DROP PROCEDURE IF EXISTS `organisation_set_retention`$
+CREATE PROCEDURE `organisation_set_retention`(
+  IN _id VARCHAR(16),
+  IN _retention_days INT,
+  IN _apply_immediately TINYINT,
+  IN _allow_members_view TINYINT,
+  IN _allow_editors_restore TINYINT
+)
+BEGIN
+  -- Versioning retention policy is org-wide; store it in organisation.metadata
+  -- (longtext JSON, already holds ident/name/owner_id). JSON_SET preserves the
+  -- existing keys. Guard against a NULL / non-JSON legacy metadata value.
+  UPDATE organisation
+  SET metadata = JSON_SET(
+    IF(metadata IS NULL OR metadata = '' OR NOT JSON_VALID(metadata), '{}', metadata),
+    '$.version_retention_days',        _retention_days,
+    '$.version_apply_immediately',     _apply_immediately,
+    '$.version_allow_members_view',    _allow_members_view,
+    '$.version_allow_editors_restore', _allow_editors_restore
+  )
+  WHERE id = _id;
+
+  SELECT ROW_COUNT() AS updated;
+END$
+
+DELIMITER ;

--- a/yellow_page/procedures/survey/survey_upsert.sql
+++ b/yellow_page/procedures/survey/survey_upsert.sql
@@ -1,0 +1,25 @@
+DELIMITER $
+
+
+-- =========================================================
+-- PMF rating survey — upsert one response row per user.
+-- Empty _answers keeps any previously stored answers (the
+-- score-only submit fires before the wizard completes).
+-- =========================================================
+DROP PROCEDURE IF EXISTS `survey_upsert`$
+CREATE PROCEDURE `survey_upsert`(
+  IN _uid VARCHAR(16),
+  IN _score TINYINT UNSIGNED,
+  IN _answers MEDIUMTEXT
+)
+BEGIN
+  INSERT INTO survey_response (uid, score, answers, ctime, mtime)
+  VALUES (_uid, _score, IF(_answers = '', NULL, _answers), UNIX_TIMESTAMP(), UNIX_TIMESTAMP())
+  ON DUPLICATE KEY UPDATE
+    score   = _score,
+    answers = IF(_answers IS NULL OR _answers = '', answers, _answers),
+    mtime   = UNIX_TIMESTAMP();
+  SELECT * FROM survey_response WHERE uid = _uid;
+END$
+
+DELIMITER ;

--- a/yellow_page/tables/survey_response.sql
+++ b/yellow_page/tables/survey_response.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS `survey_response` (
+  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `uid` varchar(16) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL COMMENT 'Reference to yp.entity.id',
+  `score` tinyint(1) unsigned NOT NULL DEFAULT 0 COMMENT '1-5 star rating',
+  `answers` mediumtext DEFAULT NULL COMMENT 'JSON: PMF survey answers (q1..q8, qb1..qb5)',
+  `ctime` int(11) unsigned NOT NULL DEFAULT 0,
+  `mtime` int(11) unsigned NOT NULL DEFAULT 0,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uni_uid` (`uid`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci
+COMMENT='PMF rating survey — one row per user, resubmit updates (upsert)'


### PR DESCRIPTION
Whole-branch promotion of `test` → `preview` for schemas.

## Ours (task-assigned notification)
- `yellow_page/procedures/contact/contact_task_assigned_unread.sql` (new)
- `yellow_page/procedures/contact/contact_log_activity.sql` (modified — dedupe task_assigned)

## Teammate work carried along (owners please confirm preview-readiness)
- **versioning-retention** (common + yp): `file_version_delete_old` (mod), `file_version_purge_expired` (new), `get_hub_version_size` (new), `organisation_cache_version_history`/`organisation_get_retention`/`organisation_list_retention`/`organisation_set_retention` (new)
- **PMF survey**: `yellow_page/tables/survey_response.sql` (new table), `survey_upsert` (new)
- **admin-console**: `hub_list_folders` (mod), `hub_member_remove` (mod), `member_save_workspace_roles` (mod)

## ⚠️ DB apply required (preview shares the PROD DB) — apply BEFORE/with server #71 + ui #243
The server/ui promotions call these SPs; without them applied, preview/prod errors on missing SPs.
- **common** (all hub+drumate instances): `file_version_delete_old`, `file_version_purge_expired`, `get_hub_version_size`
- **hub** (per instance): `hub_list_folders`, `hub_member_remove`
- **yellow_page** (yp DB): `contact_task_assigned_unread`, `contact_log_activity`, `member_save_workspace_roles`, `organisation_cache_version_history`, `organisation_get_retention`, `organisation_list_retention`, `organisation_set_retention`, `survey_upsert`, + table `survey_response`

Note: `package.json` version is `1.1.12` on both test and preview (these commits didn't bump it) — may want a version bump for tracking.
