### PR TITLE
fix(admin-stats): correct Pending-Invites + External-Guests counters

### DIFF
--- a/hub/procedures/admin/hub_member_stats.sql
+++ b/hub/procedures/admin/hub_member_stats.sql
@@ -2,7 +2,8 @@ DELIMITER $
 
 DROP PROCEDURE IF EXISTS `hub_member_stats`$
 CREATE PROCEDURE `hub_member_stats`(
-  IN _domain_id INT(11) UNSIGNED
+  IN _domain_id INT(11) UNSIGNED,
+  IN _hub_id    VARCHAR(16)
 )
 BEGIN
   SELECT
@@ -10,9 +11,33 @@ BEGIN
       AS total_members,
     COUNT(DISTINCT CASE WHEN p.permission & 16 THEN p.entity_id END)
       AS admins,
-    COUNT(DISTINCT CASE WHEN d.domain_id != _domain_id THEN p.entity_id END)
+    -- External guests = distinct external people who opened a secure share of
+    -- THIS workspace. Email-gated shares ("require external guest email") record
+    -- the guest's email in secure_share_access_event.recipient_email; COUNT(DISTINCT)
+    -- drops NULLs so anonymous/public opens don't inflate the headcount. Excludes
+    -- the org's own members (mirrors secure_share_guest_events_by_domain). This
+    -- replaces the previous "cross-domain member" definition, which counted
+    -- registered users from other orgs, not secure-share link guests.
+    (
+      SELECT COUNT(DISTINCT ae.recipient_email)
+      FROM yp.secure_share_access_event ae
+      INNER JOIN yp.secure_share_token st ON st.id = ae.token_id
+      LEFT JOIN yp.drumate viewer ON viewer.id = ae.actor_id
+      WHERE st.hub_id = _hub_id
+        AND (ae.actor_id IS NULL
+             OR viewer.domain_id IS NULL
+             OR viewer.domain_id != _domain_id)
+    )
       AS external_guests,
-    0
+    -- Pending invites = people invited to THIS workspace by email who have not
+    -- joined yet (still parked in yp.pending_invitation, keyed on hub_id+email),
+    -- excluding expired invites. Was hardcoded 0.
+    (
+      SELECT COUNT(*)
+      FROM yp.pending_invitation pi
+      WHERE pi.hub_id = _hub_id
+        AND (pi.expiry_time = 0 OR pi.expiry_time > UNIX_TIMESTAMP())
+    )
       AS pending_invites,
     -- Most recent content activity in the hub. media.publish_time is the
     -- canonical "last modified" timestamp on a file/folder; entity.mtime

--- a/patches/manifest.txt
+++ b/patches/manifest.txt
@@ -2,6 +2,8 @@
   yellow_page/procedures/secure_share/secure_share_guest_events_by_domain.sql
   yellow_page/procedures/secure_share/secure_share_guest_events_by_domain_count.sql
   yellow_page/procedures/adminpannel/member_save_workspace_roles.sql
+  yellow_page/procedures/adminpannel/member_list_stats.sql
+  hub/procedures/admin/hub_member_stats.sql
   hub/procedures/admin/hub_member_remove.sql
   yellow_page/procedures/organization/organisation_get_retention.sql
   yellow_page/procedures/organization/organisation_set_retention.sql

--- a/yellow_page/procedures/adminpannel/member_list_stats.sql
+++ b/yellow_page/procedures/adminpannel/member_list_stats.sql
@@ -12,12 +12,24 @@ BEGIN
   SELECT
     COUNT(DISTINCT p.uid) AS total_members,
     SUM(CASE WHEN p.privilege > 1 THEN 1 ELSE 0 END) AS admins,
-    SUM(CASE WHEN d.connected = '0' AND e.status = 'active' THEN 1 ELSE 0 END) AS pending_invites,
+    SUM(CASE WHEN COALESCE(d.connected, '0') = '0' AND e.status = 'active' THEN 1 ELSE 0 END) AS pending_invites,
     (
-      SELECT COUNT(DISTINCT dt.guest_id)
-      FROM dmz_token dt
-      INNER JOIN hub h ON h.id = dt.hub_id
-      WHERE h.domain_id = _dom_id
+      -- External guests = distinct external people who opened a secure share
+      -- created by a member of this org. Mirrors secure_share_guest_events_by_domain
+      -- (the "External Guest Activity" audit table): scope by the share creator's
+      -- domain, exclude the org's own members (anonymous + other-domain accounts
+      -- are kept). Email-gated shares ("require external guest email") record the
+      -- guest's email in recipient_email; COUNT(DISTINCT) drops NULLs so ungated
+      -- anonymous opens don't inflate the headcount. This replaces the legacy
+      -- dmz_token source, which the secure-share flow never writes to.
+      SELECT COUNT(DISTINCT ae.recipient_email)
+      FROM secure_share_access_event ae
+      INNER JOIN secure_share_token st ON st.id = ae.token_id
+      INNER JOIN drumate owner ON owner.id = st.creator_id AND owner.domain_id = _dom_id
+      LEFT JOIN drumate viewer ON viewer.id = ae.actor_id
+      WHERE ae.actor_id IS NULL
+         OR viewer.domain_id IS NULL
+         OR viewer.domain_id != _dom_id
     ) AS external_guests
   FROM privilege p
   INNER JOIN organisation o ON p.domain_id = o.domain_id
@@ -26,7 +38,7 @@ BEGIN
   WHERE
     o.id = _org_id AND
     p.domain_id = _dom_id AND
-    JSON_VALUE(d.profile, '$.category') != 'system' AND
+    COALESCE(JSON_VALUE(d.profile, '$.category'), '') <> 'system' AND
     e.status != 'archived';
 END $
 


### PR DESCRIPTION
Pending Invites (hub_member_stats) was hardcoded 0 → counts `pending_invitation`. External Guests read the legacy `dmz_token` (never written by secure shares) → reads `secure_share_access_event`. Adds `_hub_id` param to hub_member_stats + NULL-safe category gate in member_list_stats. Deployed + verified on stage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)