### PR TITLE
fix(admin-storage): read used storage from disk_usage, not dead entity.space

### DIFF
--- a/patches/manifest.txt
+++ b/patches/manifest.txt
@@ -2,6 +2,8 @@
   yellow_page/procedures/secure_share/secure_share_guest_events_by_domain.sql
   yellow_page/procedures/secure_share/secure_share_guest_events_by_domain_count.sql
   yellow_page/procedures/adminpannel/member_save_workspace_roles.sql
+  yellow_page/procedures/adminpannel/get_org_user_storage.sql
+  yellow_page/procedures/adminpannel/get_org_storage_stats.sql
   hub/procedures/admin/hub_member_remove.sql
   yellow_page/procedures/organization/organisation_get_retention.sql
   yellow_page/procedures/organization/organisation_set_retention.sql

--- a/yellow_page/procedures/adminpannel/get_org_storage_stats.sql
+++ b/yellow_page/procedures/adminpannel/get_org_storage_stats.sql
@@ -5,19 +5,23 @@ CREATE PROCEDURE `get_org_storage_stats`(
   IN _domain_id INT(11) UNSIGNED
 )
 BEGIN
+  -- Per-hub used storage from the maintained yp.disk_usage table (keyed by
+  -- hub_id). The previous source (entity.space) is a dead column — 0 for every
+  -- hub — so the org storage breakdown read 0 B for every workspace.
+  -- hub_name: entity.ident is often NULL on freshly-created hubs, so fall back
+  -- through yp.hub.name then hubname (same chain as member_list_workspaces).
   SELECT
     e.id AS hub_id,
-    e.ident AS hub_name,
-    COALESCE(e.space, 0) AS used_bytes,
-    ROUND(
-      COALESCE(e.space, 0) / 1048576,
-      2
-    ) AS used_mb
+    IFNULL(IFNULL(e.ident, h.name), h.hubname) AS hub_name,
+    COALESCE(du.size, 0) AS used_bytes,
+    ROUND(COALESCE(du.size, 0) / 1048576, 2) AS used_mb
   FROM yp.entity e
+  LEFT JOIN yp.disk_usage du ON du.hub_id = e.id
+  LEFT JOIN yp.hub h ON h.id = e.id
   WHERE e.dom_id = _domain_id
     AND e.type = 'hub'
     AND e.status = 'active'
-  ORDER BY e.space DESC;
+  ORDER BY used_bytes DESC;
 END$
 
 DELIMITER ;

--- a/yellow_page/procedures/adminpannel/get_org_user_storage.sql
+++ b/yellow_page/procedures/adminpannel/get_org_user_storage.sql
@@ -14,6 +14,11 @@ BEGIN
 
   SET _sort_by = IFNULL(_sort_by, 'usage_high');
 
+  -- Used storage = the user's maintained footprint (files in the hubs they own
+  -- + their personal space), via the canonical yp.disk_usage() function — the
+  -- same source data_usage()/disk_free()/the quota cache use. The previous
+  -- source (entity.space) is a dead column, 0 for every drumate and hub, which
+  -- made every user read 0 B used.
   SELECT
     d.id AS uid,
     d.firstname,
@@ -21,15 +26,14 @@ BEGIN
     d.fullname,
     d.email,
     p.privilege AS domain_privilege,
-    COALESCE(e.space, 0) AS used_bytes,
-    ROUND(COALESCE(e.space, 0) / 1048576, 2) AS used_mb
+    COALESCE(disk_usage(d.id), 0) AS used_bytes,
+    ROUND(COALESCE(disk_usage(d.id), 0) / 1048576, 2) AS used_mb
   FROM yp.drumate d
   INNER JOIN yp.privilege p ON p.uid = d.id
-  LEFT JOIN yp.entity e ON e.id = d.id AND e.type = 'drumate'
   WHERE d.domain_id = _domain_id
   ORDER BY
-    CASE WHEN _sort_by = 'usage_high' THEN COALESCE(e.space, 0) END DESC,
-    CASE WHEN _sort_by = 'usage_low' THEN COALESCE(e.space, 0) END ASC,
+    CASE WHEN _sort_by = 'usage_high' THEN used_bytes END DESC,
+    CASE WHEN _sort_by = 'usage_low' THEN used_bytes END ASC,
     d.lastname ASC
   LIMIT _offset, _range;
 END$


### PR DESCRIPTION
Admin-console Storage tab showed 0 B for every user + every workspace: get_org_user_storage and get_org_storage_stats sourced used_bytes from yp.entity.space, a column that is 0 for every drumate and hub. Switch to the maintained yp.disk_usage source — per-user via the canonical yp.disk_usage() function (owned hubs + personal, same source as data_usage/quota cache), per-hub via disk_usage.size; also resolve blank hub_name. Deployed to yp + verified live (owner 0.62 GB / total 624 MB, was 0). No FE change. Investigation: _bmad-output/implementation-artifacts/investigations/admin-storage-per-user-investigation.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)