### PR TITLE
fix(admin-console): stat counters + storage source (consolidated)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [Unreleased] — 2026-07-07
+
+### Admin console — member stat counters
+- **Fixed**: `yellow_page/procedures/adminpannel/member_list_stats.sql` — Pending Invites now counts unaccepted members via a NULL-safe category gate; External Guests read the legacy `dmz_token` (never written by secure shares) → `secure_share_access_event`; Admins counted `privilege > 1` (over-counting write-capable members) → count the admin bit (`privilege & 16`), matching `hub_member_stats` and the role labels
+- **Updated**: `hub/procedures/admin/hub_member_stats.sql` — adds `_hub_id` param; per-workspace Pending Invites (was hardcoded `0`) now from `yp.pending_invitation`; External Guests (was cross-domain members) now distinct guests from `secure_share_access_event` for the hub
+- **Added**: `yellow_page/procedures/adminpannel/pending_invites_by_domain.sql` — lists pending workspace invites (email + workspace + expiry) for the Pending Invites stat-card popup; optional `_hub_id` narrows to one workspace
+
+### Admin console — Storage tab
+- **Fixed**: `yellow_page/procedures/adminpannel/get_org_user_storage.sql` — per-user used storage read from the dead `entity.space` column (`0` for every user) → the canonical `yp.disk_usage()` function (owned hubs + personal), the same source `data_usage()`/`disk_free()`/the quota cache use
+- **Fixed**: `yellow_page/procedures/adminpannel/get_org_storage_stats.sql` — per-hub used storage read from `entity.space` (`0`) → `disk_usage.size`; resolve blank `hub_name` via the `ident → hub.name → hubname` fallback
+
 ## [Unreleased] — 2026-06-10
 
 ### Hub invite — workspace shown as ID instead of name

--- a/hub/procedures/admin/hub_member_stats.sql
+++ b/hub/procedures/admin/hub_member_stats.sql
@@ -2,7 +2,8 @@ DELIMITER $
 
 DROP PROCEDURE IF EXISTS `hub_member_stats`$
 CREATE PROCEDURE `hub_member_stats`(
-  IN _domain_id INT(11) UNSIGNED
+  IN _domain_id INT(11) UNSIGNED,
+  IN _hub_id    VARCHAR(16)
 )
 BEGIN
   SELECT
@@ -10,9 +11,33 @@ BEGIN
       AS total_members,
     COUNT(DISTINCT CASE WHEN p.permission & 16 THEN p.entity_id END)
       AS admins,
-    COUNT(DISTINCT CASE WHEN d.domain_id != _domain_id THEN p.entity_id END)
+    -- External guests = distinct external people who opened a secure share of
+    -- THIS workspace. Email-gated shares ("require external guest email") record
+    -- the guest's email in secure_share_access_event.recipient_email; COUNT(DISTINCT)
+    -- drops NULLs so anonymous/public opens don't inflate the headcount. Excludes
+    -- the org's own members (mirrors secure_share_guest_events_by_domain). This
+    -- replaces the previous "cross-domain member" definition, which counted
+    -- registered users from other orgs, not secure-share link guests.
+    (
+      SELECT COUNT(DISTINCT ae.recipient_email)
+      FROM yp.secure_share_access_event ae
+      INNER JOIN yp.secure_share_token st ON st.id = ae.token_id
+      LEFT JOIN yp.drumate viewer ON viewer.id = ae.actor_id
+      WHERE st.hub_id = _hub_id
+        AND (ae.actor_id IS NULL
+             OR viewer.domain_id IS NULL
+             OR viewer.domain_id != _domain_id)
+    )
       AS external_guests,
-    0
+    -- Pending invites = people invited to THIS workspace by email who have not
+    -- joined yet (still parked in yp.pending_invitation, keyed on hub_id+email),
+    -- excluding expired invites. Was hardcoded 0.
+    (
+      SELECT COUNT(*)
+      FROM yp.pending_invitation pi
+      WHERE pi.hub_id = _hub_id
+        AND (pi.expiry_time = 0 OR pi.expiry_time > UNIX_TIMESTAMP())
+    )
       AS pending_invites,
     -- Most recent content activity in the hub. media.publish_time is the
     -- canonical "last modified" timestamp on a file/folder; entity.mtime

--- a/patches/changelog.txt
+++ b/patches/changelog.txt
@@ -1,3 +1,10 @@
+2026-07-07
+  yellow_page/procedures/adminpannel/member_list_stats.sql
+  yellow_page/procedures/adminpannel/pending_invites_by_domain.sql
+  yellow_page/procedures/adminpannel/get_org_user_storage.sql
+  yellow_page/procedures/adminpannel/get_org_storage_stats.sql
+  hub/procedures/admin/hub_member_stats.sql
+
 2026-07-03
   yellow_page/procedures/secure_share/secure_share_list_access_events.sql
   yellow_page/procedures/secure_share/secure_share_guest_events_by_domain_count.sql

--- a/patches/manifest.txt
+++ b/patches/manifest.txt
@@ -3,6 +3,7 @@
   yellow_page/procedures/secure_share/secure_share_guest_events_by_domain_count.sql
   yellow_page/procedures/adminpannel/member_save_workspace_roles.sql
   yellow_page/procedures/adminpannel/member_list_stats.sql
+  yellow_page/procedures/adminpannel/pending_invites_by_domain.sql
   hub/procedures/admin/hub_member_stats.sql
   hub/procedures/admin/hub_member_remove.sql
   yellow_page/procedures/organization/organisation_get_retention.sql

--- a/patches/manifest.txt
+++ b/patches/manifest.txt
@@ -2,6 +2,8 @@
   yellow_page/procedures/secure_share/secure_share_guest_events_by_domain.sql
   yellow_page/procedures/secure_share/secure_share_guest_events_by_domain_count.sql
   yellow_page/procedures/adminpannel/member_save_workspace_roles.sql
+  yellow_page/procedures/adminpannel/member_list_stats.sql
+  hub/procedures/admin/hub_member_stats.sql
   hub/procedures/admin/hub_member_remove.sql
   yellow_page/procedures/organization/organisation_get_retention.sql
   yellow_page/procedures/organization/organisation_set_retention.sql

--- a/patches/manifest.txt
+++ b/patches/manifest.txt
@@ -2,6 +2,8 @@
   yellow_page/procedures/secure_share/secure_share_guest_events_by_domain.sql
   yellow_page/procedures/secure_share/secure_share_guest_events_by_domain_count.sql
   yellow_page/procedures/adminpannel/member_save_workspace_roles.sql
+  yellow_page/procedures/adminpannel/get_org_user_storage.sql
+  yellow_page/procedures/adminpannel/get_org_storage_stats.sql
   hub/procedures/admin/hub_member_remove.sql
   yellow_page/procedures/organization/organisation_get_retention.sql
   yellow_page/procedures/organization/organisation_set_retention.sql

--- a/yellow_page/procedures/adminpannel/get_org_storage_stats.sql
+++ b/yellow_page/procedures/adminpannel/get_org_storage_stats.sql
@@ -5,19 +5,23 @@ CREATE PROCEDURE `get_org_storage_stats`(
   IN _domain_id INT(11) UNSIGNED
 )
 BEGIN
+  -- Per-hub used storage from the maintained yp.disk_usage table (keyed by
+  -- hub_id). The previous source (entity.space) is a dead column — 0 for every
+  -- hub — so the org storage breakdown read 0 B for every workspace.
+  -- hub_name: entity.ident is often NULL on freshly-created hubs, so fall back
+  -- through yp.hub.name then hubname (same chain as member_list_workspaces).
   SELECT
     e.id AS hub_id,
-    e.ident AS hub_name,
-    COALESCE(e.space, 0) AS used_bytes,
-    ROUND(
-      COALESCE(e.space, 0) / 1048576,
-      2
-    ) AS used_mb
+    IFNULL(IFNULL(e.ident, h.name), h.hubname) AS hub_name,
+    COALESCE(du.size, 0) AS used_bytes,
+    ROUND(COALESCE(du.size, 0) / 1048576, 2) AS used_mb
   FROM yp.entity e
+  LEFT JOIN yp.disk_usage du ON du.hub_id = e.id
+  LEFT JOIN yp.hub h ON h.id = e.id
   WHERE e.dom_id = _domain_id
     AND e.type = 'hub'
     AND e.status = 'active'
-  ORDER BY e.space DESC;
+  ORDER BY used_bytes DESC;
 END$
 
 DELIMITER ;

--- a/yellow_page/procedures/adminpannel/get_org_user_storage.sql
+++ b/yellow_page/procedures/adminpannel/get_org_user_storage.sql
@@ -14,6 +14,11 @@ BEGIN
 
   SET _sort_by = IFNULL(_sort_by, 'usage_high');
 
+  -- Used storage = the user's maintained footprint (files in the hubs they own
+  -- + their personal space), via the canonical yp.disk_usage() function — the
+  -- same source data_usage()/disk_free()/the quota cache use. The previous
+  -- source (entity.space) is a dead column, 0 for every drumate and hub, which
+  -- made every user read 0 B used.
   SELECT
     d.id AS uid,
     d.firstname,
@@ -21,15 +26,14 @@ BEGIN
     d.fullname,
     d.email,
     p.privilege AS domain_privilege,
-    COALESCE(e.space, 0) AS used_bytes,
-    ROUND(COALESCE(e.space, 0) / 1048576, 2) AS used_mb
+    COALESCE(disk_usage(d.id), 0) AS used_bytes,
+    ROUND(COALESCE(disk_usage(d.id), 0) / 1048576, 2) AS used_mb
   FROM yp.drumate d
   INNER JOIN yp.privilege p ON p.uid = d.id
-  LEFT JOIN yp.entity e ON e.id = d.id AND e.type = 'drumate'
   WHERE d.domain_id = _domain_id
   ORDER BY
-    CASE WHEN _sort_by = 'usage_high' THEN COALESCE(e.space, 0) END DESC,
-    CASE WHEN _sort_by = 'usage_low' THEN COALESCE(e.space, 0) END ASC,
+    CASE WHEN _sort_by = 'usage_high' THEN used_bytes END DESC,
+    CASE WHEN _sort_by = 'usage_low' THEN used_bytes END ASC,
     d.lastname ASC
   LIMIT _offset, _range;
 END$

--- a/yellow_page/procedures/adminpannel/member_list_stats.sql
+++ b/yellow_page/procedures/adminpannel/member_list_stats.sql
@@ -12,12 +12,24 @@ BEGIN
   SELECT
     COUNT(DISTINCT p.uid) AS total_members,
     SUM(CASE WHEN p.privilege > 1 THEN 1 ELSE 0 END) AS admins,
-    SUM(CASE WHEN d.connected = '0' AND e.status = 'active' THEN 1 ELSE 0 END) AS pending_invites,
+    SUM(CASE WHEN COALESCE(d.connected, '0') = '0' AND e.status = 'active' THEN 1 ELSE 0 END) AS pending_invites,
     (
-      SELECT COUNT(DISTINCT dt.guest_id)
-      FROM dmz_token dt
-      INNER JOIN hub h ON h.id = dt.hub_id
-      WHERE h.domain_id = _dom_id
+      -- External guests = distinct external people who opened a secure share
+      -- created by a member of this org. Mirrors secure_share_guest_events_by_domain
+      -- (the "External Guest Activity" audit table): scope by the share creator's
+      -- domain, exclude the org's own members (anonymous + other-domain accounts
+      -- are kept). Email-gated shares ("require external guest email") record the
+      -- guest's email in recipient_email; COUNT(DISTINCT) drops NULLs so ungated
+      -- anonymous opens don't inflate the headcount. This replaces the legacy
+      -- dmz_token source, which the secure-share flow never writes to.
+      SELECT COUNT(DISTINCT ae.recipient_email)
+      FROM secure_share_access_event ae
+      INNER JOIN secure_share_token st ON st.id = ae.token_id
+      INNER JOIN drumate owner ON owner.id = st.creator_id AND owner.domain_id = _dom_id
+      LEFT JOIN drumate viewer ON viewer.id = ae.actor_id
+      WHERE ae.actor_id IS NULL
+         OR viewer.domain_id IS NULL
+         OR viewer.domain_id != _dom_id
     ) AS external_guests
   FROM privilege p
   INNER JOIN organisation o ON p.domain_id = o.domain_id
@@ -26,7 +38,7 @@ BEGIN
   WHERE
     o.id = _org_id AND
     p.domain_id = _dom_id AND
-    JSON_VALUE(d.profile, '$.category') != 'system' AND
+    COALESCE(JSON_VALUE(d.profile, '$.category'), '') <> 'system' AND
     e.status != 'archived';
 END $
 

--- a/yellow_page/procedures/adminpannel/member_list_stats.sql
+++ b/yellow_page/procedures/adminpannel/member_list_stats.sql
@@ -11,7 +11,10 @@ BEGIN
 
   SELECT
     COUNT(DISTINCT p.uid) AS total_members,
-    SUM(CASE WHEN p.privilege > 1 THEN 1 ELSE 0 END) AS admins,
+    -- Admins = members carrying the admin permission bit (16), matching
+    -- hub_member_stats (`permission & 16`) and the role labels. The old
+    -- `privilege > 1` over-counted every write-capable member as an admin.
+    SUM(CASE WHEN p.privilege & 16 THEN 1 ELSE 0 END) AS admins,
     SUM(CASE WHEN COALESCE(d.connected, '0') = '0' AND e.status = 'active' THEN 1 ELSE 0 END) AS pending_invites,
     (
       -- External guests = distinct external people who opened a secure share

--- a/yellow_page/procedures/adminpannel/pending_invites_by_domain.sql
+++ b/yellow_page/procedures/adminpannel/pending_invites_by_domain.sql
@@ -1,0 +1,32 @@
+DELIMITER $
+
+DROP PROCEDURE IF EXISTS `pending_invites_by_domain`$
+CREATE PROCEDURE `pending_invites_by_domain`(
+  IN _dom_id INT,
+  IN _hub_id VARCHAR(16)
+)
+BEGIN
+  -- Backing list for the admin-console "Pending Invites" stat-card popup:
+  -- people invited to a workspace by email who have not joined yet (still parked
+  -- in pending_invitation, keyed hub_id+email). Scoped to the caller's domain,
+  -- optionally narrowed to a single workspace (_hub_id; '' or NULL = whole org),
+  -- excluding expired invites. Workspace name resolved like member_list_workspaces.
+  SELECT
+    pi.email,
+    pi.hub_id,
+    pi.permission,
+    pi.expiry_time,
+    pi.created_at,
+    IFNULL(IFNULL(e.ident, h.name), h.hubname) AS workspace_name
+  FROM pending_invitation pi
+  INNER JOIN entity e ON e.id = pi.hub_id
+  LEFT JOIN hub h ON h.id = pi.hub_id
+  WHERE e.dom_id = _dom_id
+    AND e.type = 'hub'
+    AND e.status = 'active'
+    AND (_hub_id IS NULL OR _hub_id = '' OR pi.hub_id = _hub_id)
+    AND (pi.expiry_time = 0 OR pi.expiry_time > UNIX_TIMESTAMP())
+  ORDER BY pi.created_at DESC;
+END $
+
+DELIMITER ;


### PR DESCRIPTION
Consolidated admin-console DB fixes (supersedes #41, #42, #43):
- **Stat counters** (member_list_stats, hub_member_stats): Pending Invites (was hardcoded 0 → pending_invitation), External Guests (dmz_token/cross-domain → secure_share_access_event), admins counts the admin bit not privilege>1, NULL-safe category gate; hub_member_stats takes _hub_id.
- **Pending list** (pending_invites_by_domain): backs the Pending Invites popup.
- **Storage source** (get_org_user_storage, get_org_storage_stats): read used bytes from yp.disk_usage (per-user via disk_usage() fn, per-hub via disk_usage.size) instead of the dead entity.space column; resolve hub_name.

All deployed to yp on stage + verified live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)