### PR TITLE
feat(admin-console): add get_org_quota for Storage tab quota bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Admin console — Storage tab
 - **Fixed**: `yellow_page/procedures/adminpannel/get_org_user_storage.sql` — per-user used storage read from the dead `entity.space` column (`0` for every user) → the canonical `yp.disk_usage()` function (owned hubs + personal), the same source `data_usage()`/`disk_free()`/the quota cache use
 - **Fixed**: `yellow_page/procedures/adminpannel/get_org_storage_stats.sql` — per-hub used storage read from `entity.space` (`0`) → `disk_usage.size`; resolve blank `hub_name` via the `ident → hub.name → hubname` fallback
+- **Added**: `yellow_page/procedures/adminpannel/get_org_quota.sql` — domain storage limit (`yp.quota.disk`) and cached usage (`yp.quota_usage`) for the admin Storage tab quota bar
 
 ## [Unreleased] — 2026-06-10
 

--- a/patches/changelog.txt
+++ b/patches/changelog.txt
@@ -3,6 +3,7 @@
   yellow_page/procedures/adminpannel/pending_invites_by_domain.sql
   yellow_page/procedures/adminpannel/get_org_user_storage.sql
   yellow_page/procedures/adminpannel/get_org_storage_stats.sql
+  yellow_page/procedures/adminpannel/get_org_quota.sql
   hub/procedures/admin/hub_member_stats.sql
 
 2026-07-06

--- a/patches/manifest.txt
+++ b/patches/manifest.txt
@@ -6,6 +6,7 @@
   yellow_page/procedures/adminpannel/pending_invites_by_domain.sql
   yellow_page/procedures/adminpannel/get_org_user_storage.sql
   yellow_page/procedures/adminpannel/get_org_storage_stats.sql
+  yellow_page/procedures/adminpannel/get_org_quota.sql
   hub/procedures/admin/hub_member_stats.sql
   hub/procedures/admin/hub_member_remove.sql
   yellow_page/procedures/organization/organisation_get_retention.sql

--- a/yellow_page/procedures/adminpannel/get_org_quota.sql
+++ b/yellow_page/procedures/adminpannel/get_org_quota.sql
@@ -1,0 +1,29 @@
+DELIMITER $
+
+DROP PROCEDURE IF EXISTS `get_org_quota`$
+CREATE PROCEDURE `get_org_quota`(
+  IN _domain_id INT(11) UNSIGNED
+)
+BEGIN
+  -- Domain storage limit (yp.quota.disk) vs cached org usage (yp.quota_usage).
+  -- Mirrors the quota slice of hub/procedures/admin/get_hub_storage_stats.sql.
+  SELECT
+    _domain_id AS domain_id,
+    COALESCE(q.disk, 0) AS quota_bytes,
+    COALESCE(qu.cached_usage, 0) AS used_bytes,
+    IF(COALESCE(q.disk, 0) > 0,
+      ROUND((COALESCE(qu.cached_usage, 0) / q.disk) * 100, 1),
+      0) AS usage_pct,
+    IF(COALESCE(q.disk, 0) > 0,
+      GREATEST(COALESCE(q.disk, 0) - COALESCE(qu.cached_usage, 0), 0),
+      0) AS available_bytes,
+    IF(COALESCE(q.disk, 0) > 0
+      AND (COALESCE(qu.cached_usage, 0) / q.disk) >= 0.9,
+      1, 0) AS low_storage_alert
+  FROM yp.quota q
+  LEFT JOIN yp.quota_usage qu ON qu.domain_id = q.domain_id
+  WHERE q.domain_id = _domain_id
+  LIMIT 1;
+END$
+
+DELIMITER ;


### PR DESCRIPTION
## Summary
- Thêm stored procedure `get_org_quota` để admin Storage tab đọc quota disk thật (`yp.quota.disk`) và usage đã cache (`yp.quota_usage`).
- Cập nhật `patches/manifest.txt`, `patches/changelog.txt`, và `CHANGELOG.md`.

## Test plan
- [ ] Patch proc lên YP: `bin/patch-from-file yellow_page/procedures/adminpannel/get_org_quota.sql yp`
- [ ] Gọi `get_org_quota` với domain hợp lệ → trả disk limit + cached usage
- [ ] Admin Console tab Storage hiển thị quota bar với data thật


Made with [Cursor](https://cursor.com)