### PR TITLE
Promote schemas test → preview (mfs_show_node_by index migration v1.1.15, behaviour-neutral)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Admin console — Storage tab
 - **Fixed**: `yellow_page/procedures/adminpannel/get_org_user_storage.sql` — per-user used storage read from the dead `entity.space` column (`0` for every user) → the canonical `yp.disk_usage()` function (owned hubs + personal), the same source `data_usage()`/`disk_free()`/the quota cache use
 - **Fixed**: `yellow_page/procedures/adminpannel/get_org_storage_stats.sql` — per-hub used storage read from `entity.space` (`0`) → `disk_usage.size`; resolve blank `hub_name` via the `ident → hub.name → hubname` fallback
+- **Added**: `yellow_page/procedures/adminpannel/get_org_quota.sql` — domain storage limit (`yp.quota.disk`) and cached usage (`yp.quota_usage`) for the admin Storage tab quota bar
 
 ## [Unreleased] — 2026-06-10
 

--- a/common/procedures/mfs/mfs_show_node_by.sql
+++ b/common/procedures/mfs/mfs_show_node_by.sql
@@ -119,26 +119,23 @@ BEGIN
     latest_event_id INT(11) UNSIGNED
   );
 
-  -- Populate with latest changelog event per node
+  -- Populate with latest changelog event per node.
+  -- `nid` is a VIRTUAL generated column on yp.mfs_changelog
+  -- (= COALESCE(JSON_VALUE(src,'$.nid'), JSON_VALUE(dest,'$.nid'))) indexed by
+  -- idx_nid(nid, id). Referencing it directly lets this GROUP BY + MAX(id) run as
+  -- a covering index scan instead of a full table scan with per-row JSON parsing.
+  -- (Requires the idx_nid migration applied to yp.mfs_changelog — shipped first.)
   INSERT INTO _temp_latest_events (nid, latest_event_id)
-  SELECT
-    COALESCE(
-      JSON_VALUE(src,  '$.nid'),
-      JSON_VALUE(dest, '$.nid')
-    ) AS nid,
-    MAX(id) AS latest_event_id
+  SELECT nid, MAX(id) AS latest_event_id
   FROM yp.mfs_changelog
-  WHERE COALESCE(JSON_VALUE(src, '$.nid'), JSON_VALUE(dest, '$.nid')) IS NOT NULL
-    AND CHAR_LENGTH(COALESCE(JSON_VALUE(src, '$.nid'), JSON_VALUE(dest, '$.nid'))) <= 16
+  WHERE nid IS NOT NULL
+    AND CHAR_LENGTH(nid) <= 16
     -- new_file only flags events newer than the caller's last read, so rows with
     -- id <= _last_read_id can never set new_file=1 (see the new_file CASE below).
     -- Excluding them keeps this an incremental scan instead of aggregating the
     -- entire global changelog on every listing.
     AND id > _last_read_id
-  GROUP BY COALESCE(
-    JSON_VALUE(src,  '$.nid'),
-    JSON_VALUE(dest, '$.nid')
-  );
+  GROUP BY nid;
 
   DROP TABLE IF EXISTS _temp_show_node;
   CREATE TEMPORARY TABLE _temp_show_node AS

--- a/hub/procedures/channel/channel_list_messages.sql
+++ b/hub/procedures/channel/channel_list_messages.sql
@@ -48,7 +48,8 @@ BEGIN
     IFNULL(read_json_object(c.metadata, 'message_type'), 'chat') message_type,
     COALESCE(d.firstname, du.name, '') firstname,
     COALESCE(d.lastname, '') lastname,
-    COALESCE(CONCAT(d.firstname, ' ', d.lastname), du.name, '') fullname,
+    COALESCE(NULLIF(TRIM(CONCAT(IFNULL(d.firstname, ''), ' ', IFNULL(d.lastname, ''))), ''), d.fullname, du.name, '') fullname,
+    COALESCE(d.email, du.email) email,
     CASE WHEN _old_ref_sys_id  <  c.sys_id THEN 1 ELSE 0 END is_notify,
     CASE WHEN JSON_EXISTS(metadata, CONCAT("$._seen_.", _uid))= 1 THEN 1 ELSE 0 END is_readed,
     CASE WHEN JSON_LENGTH(metadata , '$._seen_')  >=  JSON_LENGTH(metadata , '$._delivered_')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drumee/schemas",
-  "version": "1.1.14",
+  "version": "1.1.15",
   "description": "Drumee schemas",
   "main": "bin/patch.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@drumee/schemas",
-  "version": "1.1.15",
+  "version": "1.1.16",
   "description": "Drumee schemas",
   "main": "bin/patch.js",
   "repository": {

--- a/patches/changelog.txt
+++ b/patches/changelog.txt
@@ -3,6 +3,7 @@
   yellow_page/procedures/adminpannel/pending_invites_by_domain.sql
   yellow_page/procedures/adminpannel/get_org_user_storage.sql
   yellow_page/procedures/adminpannel/get_org_storage_stats.sql
+  yellow_page/procedures/adminpannel/get_org_quota.sql
   hub/procedures/admin/hub_member_stats.sql
 
 2026-07-06

--- a/patches/changelog.txt
+++ b/patches/changelog.txt
@@ -1,4 +1,5 @@
 2026-07-07
+  hub/procedures/channel/channel_list_messages.sql
   yellow_page/procedures/adminpannel/member_list_stats.sql
   yellow_page/procedures/adminpannel/pending_invites_by_domain.sql
   yellow_page/procedures/adminpannel/get_org_user_storage.sql

--- a/patches/changelog.txt
+++ b/patches/changelog.txt
@@ -8,6 +8,7 @@
   hub/procedures/admin/hub_member_stats.sql
   yellow_page/patches/add_nid_to_mfs_changelog.sql
   yellow_page/tables/mfs_changelog.sql
+  common/procedures/mfs/mfs_show_node_by.sql
 
 2026-07-06
   common/procedures/mfs/mfs_show_node_by.sql

--- a/patches/changelog.txt
+++ b/patches/changelog.txt
@@ -6,6 +6,8 @@
   yellow_page/procedures/adminpannel/get_org_storage_stats.sql
   yellow_page/procedures/adminpannel/get_org_quota.sql
   hub/procedures/admin/hub_member_stats.sql
+  yellow_page/patches/add_nid_to_mfs_changelog.sql
+  yellow_page/tables/mfs_changelog.sql
 
 2026-07-06
   common/procedures/mfs/mfs_show_node_by.sql

--- a/patches/manifest.txt
+++ b/patches/manifest.txt
@@ -6,6 +6,7 @@
   yellow_page/procedures/adminpannel/pending_invites_by_domain.sql
   yellow_page/procedures/adminpannel/get_org_user_storage.sql
   yellow_page/procedures/adminpannel/get_org_storage_stats.sql
+  yellow_page/procedures/adminpannel/get_org_quota.sql
   hub/procedures/admin/hub_member_stats.sql
   hub/procedures/admin/hub_member_remove.sql
   yellow_page/procedures/organization/organisation_get_retention.sql

--- a/yellow_page/patches/add_nid_to_mfs_changelog.sql
+++ b/yellow_page/patches/add_nid_to_mfs_changelog.sql
@@ -1,0 +1,24 @@
+-- Add an indexed generated column to yp.mfs_changelog so mfs_show_node_by's
+-- new-file detection can run as an index scan instead of full-scanning +
+-- JSON-parsing the whole changelog on every listing.
+--   nid = the node id from src/dest (the GROUP BY key in mfs_show_node_by).
+-- VIRTUAL: no stored data (instant metadata add); the index persists the
+-- computed values, so lookups/GROUP BY use idx_nid.
+--
+-- Two separate online ALTERs on purpose: MariaDB refuses to combine a virtual-
+-- column add with an index add in one INPLACE statement. IF NOT EXISTS makes
+-- this idempotent/safe to re-run.
+--
+-- ORDER: this migration MUST be applied BEFORE any mfs_show_node_by version that
+-- references the `nid` column ships. The current SP still uses the inline
+-- COALESCE(...) expression and ignores this column, so applying this alone is a
+-- no-op for behaviour and safe to deploy independently.
+
+ALTER TABLE mfs_changelog
+  ADD COLUMN IF NOT EXISTS nid VARCHAR(64) CHARACTER SET ascii
+    AS (COALESCE(JSON_VALUE(src, '$.nid'), JSON_VALUE(dest, '$.nid'))) VIRTUAL,
+  ALGORITHM=INPLACE, LOCK=SHARED;
+
+ALTER TABLE mfs_changelog
+  ADD INDEX IF NOT EXISTS idx_nid (nid, id),
+  ALGORITHM=INPLACE, LOCK=NONE;

--- a/yellow_page/procedures/adminpannel/get_org_quota.sql
+++ b/yellow_page/procedures/adminpannel/get_org_quota.sql
@@ -1,0 +1,29 @@
+DELIMITER $
+
+DROP PROCEDURE IF EXISTS `get_org_quota`$
+CREATE PROCEDURE `get_org_quota`(
+  IN _domain_id INT(11) UNSIGNED
+)
+BEGIN
+  -- Domain storage limit (yp.quota.disk) vs cached org usage (yp.quota_usage).
+  -- Mirrors the quota slice of hub/procedures/admin/get_hub_storage_stats.sql.
+  SELECT
+    _domain_id AS domain_id,
+    COALESCE(q.disk, 0) AS quota_bytes,
+    COALESCE(qu.cached_usage, 0) AS used_bytes,
+    IF(COALESCE(q.disk, 0) > 0,
+      ROUND((COALESCE(qu.cached_usage, 0) / q.disk) * 100, 1),
+      0) AS usage_pct,
+    IF(COALESCE(q.disk, 0) > 0,
+      GREATEST(COALESCE(q.disk, 0) - COALESCE(qu.cached_usage, 0), 0),
+      0) AS available_bytes,
+    IF(COALESCE(q.disk, 0) > 0
+      AND (COALESCE(qu.cached_usage, 0) / q.disk) >= 0.9,
+      1, 0) AS low_storage_alert
+  FROM yp.quota q
+  LEFT JOIN yp.quota_usage qu ON qu.domain_id = q.domain_id
+  WHERE q.domain_id = _domain_id
+  LIMIT 1;
+END$
+
+DELIMITER ;

--- a/yellow_page/tables/mfs_changelog.sql
+++ b/yellow_page/tables/mfs_changelog.sql
@@ -7,6 +7,11 @@ CREATE TABLE IF NOT EXISTS `mfs_changelog` (
   `event` VARCHAR(100) CHARACTER SET ascii COLLATE ascii_general_ci,
   src JSON,
   dest JSON DEFAULT '{}',
-  PRIMARY KEY (`id`)
+  -- Node id extracted from src/dest; indexed so mfs_show_node_by's new-file
+  -- detection uses idx_nid instead of full-scanning + JSON-parsing the table.
+  -- VIRTUAL = computed, not stored (the index persists the values).
+  `nid` VARCHAR(64) CHARACTER SET ascii AS (COALESCE(JSON_VALUE(src, '$.nid'), JSON_VALUE(dest, '$.nid'))) VIRTUAL,
+  PRIMARY KEY (`id`),
+  KEY `idx_nid` (`nid`, `id`)
 );
 


### PR DESCRIPTION
Promote `schemas` `test` → `preview` (whole branch). Headline: the `mfs_show_node_by` index migration (Somanos-approved single-column design). ⚠️ prod & preview share the DB.

## Primary (mine) — index `yp.mfs_changelog` for `mfs_show_node_by`
- `1f5f77a` + `c184a5c` (v1.1.15): add VIRTUAL column `nid = COALESCE(JSON_VALUE(src,'$.nid'), JSON_VALUE(dest,'$.nid'))` + `INDEX idx_nid(nid, id)` on `yp.mfs_changelog`.
- **MIGRATION ONLY — behaviour-neutral.** The SP still uses the inline `COALESCE(...)` expression and ignores this column, so applying this alone changes nothing at runtime and is safe to deploy independently, anytime. The SP rewrite to reference `nid` ships as a **separate follow-up, AFTER** this column is live on prod (avoids an `Unknown column 'nid'` outage from wrong ordering).

⚠️ **DB apply:** `bin/patch-from-file yellow_page/patches/add_nid_to_mfs_changelog.sql yp`. Online DDL (VIRTUAL add + `LOCK=NONE` index build), idempotent (`IF NOT EXISTS`), single `yp` table. Stage-validated: fresh apply + idempotent re-apply, table def creates cleanly, the `nid` query is EXPLAIN-covered by `idx_nid`, and output is identical to the current query (hash-verified).

## Carried teammate work (authors please sign off)
- `0145387` / `3414611` — get_org_quota (admin-console Storage tab)
- `30a5f29` — resolve chat sender name for accounts with no lastname/name
