### PR TITLE
fix(admin-console): audit filters, pending invites, and org storage totals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ node_modules/
 _bmad/
 _bmad-output/
 .claude/skills/
+investigations/*

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ _bmad/
 _bmad-output/
 .claude/skills/
 investigations/*
+!investigations/*.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,9 @@
 - **Fixed**: `yellow_page/procedures/adminpannel/member_list_stats.sql` — `pending_invites` counted never-connected drumate accounts, so inviting someone to a workspace never bumped the number → count non-expired `pending_invitation` rows on the domain's active hubs, the same source as the stat-card popup (`pending_invites_by_domain`)
 
 ### Admin console — Audit Logs action filter + target resource
-- **Added**: `common/patches/alter_action_log_add_invite_actions.sql` — extends the `action_log.action` enum with `invite_sent` / `invite_accepted` (apply to all hub and drumate DBs)
-- **Updated**: `common/tables/action_log.sql` — action enum caught up with `alter_action_log_add_actions.sql` + the two new invite actions
+- **Added**: `common/patches/alter_action_log_add_invite_actions.sql` — extends the `action_log.action` enum with `invite_sent` / `invite_accepted` (apply to all hub and drumate DBs; do **not** re-run `common/tables/action_log.sql` on existing DBs)
+- **Updated**: `common/tables/action_log.sql` — action enum caught up with `alter_action_log_add_actions.sql` + the two new invite actions (seed for new DBs only)
+- **Updated**: `templates/factory/hub.sql`, `templates/factory/drumate.sql` — `action_log.action` enum includes `invite_sent` / `invite_accepted` so newly provisioned DBs match the alter patch
 - **Updated**: `common/procedures/action_log/hub_get_audit_logs_window.sql`, `hub_get_audit_logs_count.sql` — new `_action`/`_category` filter params (`''` = no filter) for the Audit tab action filter; window proc also resolves `target_name`/`target_email` (LEFT JOIN `yp.drumate` on `entity_id`) so the FE can show a real Target Resource column
 - **Updated**: `yellow_page/procedures/adminpannel/member_list_hubs_by_domain.sql` — adds resolved hub `name` (ident → hub.name → hubname) so the audit aggregator can label rows with the workspace name
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [Unreleased] — 2026-07-08
+
+### Admin console — Pending Invites counter
+- **Fixed**: `yellow_page/procedures/adminpannel/member_list_stats.sql` — `pending_invites` counted never-connected drumate accounts, so inviting someone to a workspace never bumped the number → count non-expired `pending_invitation` rows on the domain's active hubs, the same source as the stat-card popup (`pending_invites_by_domain`)
+
+### Admin console — Audit Logs action filter + target resource
+- **Added**: `common/patches/alter_action_log_add_invite_actions.sql` — extends the `action_log.action` enum with `invite_sent` / `invite_accepted` (apply to all hub and drumate DBs)
+- **Updated**: `common/tables/action_log.sql` — action enum caught up with `alter_action_log_add_actions.sql` + the two new invite actions
+- **Updated**: `common/procedures/action_log/hub_get_audit_logs_window.sql`, `hub_get_audit_logs_count.sql` — new `_action`/`_category` filter params (`''` = no filter) for the Audit tab action filter; window proc also resolves `target_name`/`target_email` (LEFT JOIN `yp.drumate` on `entity_id`) so the FE can show a real Target Resource column
+- **Updated**: `yellow_page/procedures/adminpannel/member_list_hubs_by_domain.sql` — adds resolved hub `name` (ident → hub.name → hubname) so the audit aggregator can label rows with the workspace name
+
 ## [Unreleased] — 2026-07-07
 
 ### Admin console — member stat counters

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [Unreleased] — 2026-07-09
+
+### Admin console — Storage totals (workspace = user distribution)
+- **Updated**: `yellow_page/procedures/adminpannel/get_org_storage_stats.sql` — live `SUM(media.filesize)` per org hub (all owners) so TOTAL HUB STORAGE matches user roll-up
+- **Updated**: `yellow_page/procedures/adminpannel/get_org_user_storage.sql` — attribute bytes by `owner_id` across org hubs; include domain members + external collaborators + orphan owners (`is_external`)
+- **Updated**: `yellow_page/procedures/adminpannel/get_org_user_storage_count.sql` — count matches the user-storage roster (domain members + external/orphan owners with files)
+- **Updated**: `hub/procedures/admin/get_hub_user_storage.sql` — include non-member file owners so hub user rows reconcile with `hub_used_bytes`
+
 ## [Unreleased] — 2026-07-08
 
 ### Admin console — Pending Invites counter
@@ -10,6 +18,9 @@
 - **Updated**: `common/tables/action_log.sql` — action enum caught up with `alter_action_log_add_actions.sql` + the two new invite actions
 - **Updated**: `common/procedures/action_log/hub_get_audit_logs_window.sql`, `hub_get_audit_logs_count.sql` — new `_action`/`_category` filter params (`''` = no filter) for the Audit tab action filter; window proc also resolves `target_name`/`target_email` (LEFT JOIN `yp.drumate` on `entity_id`) so the FE can show a real Target Resource column
 - **Updated**: `yellow_page/procedures/adminpannel/member_list_hubs_by_domain.sql` — adds resolved hub `name` (ident → hub.name → hubname) so the audit aggregator can label rows with the workspace name
+
+### Admin console — External Guest Activity search
+- **Updated**: `yellow_page/procedures/secure_share/secure_share_guest_events_by_domain.sql`, `secure_share_guest_events_by_domain_count.sql` — optional search filter for guest email / share owner / workspace name
 
 ## [Unreleased] — 2026-07-07
 

--- a/common/patches/alter_action_log_add_invite_actions.sql
+++ b/common/patches/alter_action_log_add_invite_actions.sql
@@ -1,0 +1,20 @@
+-- Patch: Add invite lifecycle action types for Admin Console Audit Logs
+-- (invite_sent / invite_accepted). Apply to: all hub AND drumate DBs.
+-- Must update starter-kit manifest after applying.
+
+ALTER TABLE `action_log`
+  MODIFY `action` enum(
+    'added',
+    'deleted',
+    'changed',
+    'left',
+    'removed',
+    'backup',
+    'connection',
+    'grant_access',
+    'change_policy',
+    'share_link',
+    'create_workspace',
+    'invite_sent',
+    'invite_accepted'
+  ) DEFAULT NULL;

--- a/common/procedures/action_log/hub_get_audit_logs_count.sql
+++ b/common/procedures/action_log/hub_get_audit_logs_count.sql
@@ -3,14 +3,17 @@ DELIMITER $
 DROP PROCEDURE IF EXISTS `hub_get_audit_logs_count`$
 CREATE PROCEDURE `hub_get_audit_logs_count`(
   IN _username VARCHAR(255),
+  IN _action VARCHAR(32),
+  IN _category VARCHAR(32),
   IN _from_time INT(11),
   IN _to_time INT(11)
 )
 BEGIN
   -- Returns one row with `total` matching the same WHERE clause used by
-  -- hub_get_audit_logs_filtered. Used by yp.private/admin.get_audit_logs
+  -- hub_get_audit_logs_window. Used by yp.private/admin.get_audit_logs
   -- to sum totals across every hub in the caller's domain so the FE can
-  -- render an accurate paginator.
+  -- render an accurate paginator. _action/_category ('' = no filter)
+  -- back the Audit tab action filter.
   SELECT COUNT(*) AS total
   FROM action_log a
   INNER JOIN yp.drumate d ON d.id = a.uid
@@ -22,6 +25,8 @@ BEGIN
     d.fullname  LIKE CONCAT('%', _username, '%') OR
     d.email     LIKE CONCAT('%', _username, '%')
   )
+  AND (_action   = '' OR _action   IS NULL OR a.action   = _action)
+  AND (_category = '' OR _category IS NULL OR a.category = _category)
   AND (_from_time = 0 OR a.ctime >= _from_time)
   AND (_to_time   = 0 OR a.ctime <= _to_time);
 END$

--- a/common/procedures/action_log/hub_get_audit_logs_window.sql
+++ b/common/procedures/action_log/hub_get_audit_logs_window.sql
@@ -3,6 +3,8 @@ DELIMITER $
 DROP PROCEDURE IF EXISTS `hub_get_audit_logs_window`$
 CREATE PROCEDURE `hub_get_audit_logs_window`(
   IN _username VARCHAR(255),
+  IN _action VARCHAR(32),
+  IN _category VARCHAR(32),
   IN _from_time INT(11),
   IN _to_time INT(11),
   IN _limit INT(11)
@@ -14,6 +16,10 @@ BEGIN
   -- every hub, merges by ctime DESC, then slices the requested page —
   -- this guarantees correct cross-hub pagination, which the page-per-hub
   -- variant could not produce.
+  -- _action/_category ('' = no filter) back the Audit tab action filter.
+  -- target_name/target_email resolve entity_id when it points at a member
+  -- (member/permission rows) so the FE can show a proper Target Resource
+  -- instead of parsing the free-text log.
   IF _limit IS NULL OR _limit <= 0 THEN
     SET _limit = 200;
   END IF;
@@ -29,9 +35,12 @@ BEGIN
     CONCAT(d.firstname, ' ', d.lastname) AS actor_name,
     d.firstname,
     d.lastname,
-    d.email
+    d.email,
+    CONCAT(t.firstname, ' ', t.lastname) AS target_name,
+    t.email AS target_email
   FROM action_log a
   INNER JOIN yp.drumate d ON d.id = a.uid
+  LEFT JOIN yp.drumate t ON t.id = a.entity_id
   WHERE (
     _username = '' OR _username IS NULL OR
     CONCAT(d.firstname, ' ', d.lastname) LIKE CONCAT('%', _username, '%') OR
@@ -40,6 +49,8 @@ BEGIN
     d.fullname  LIKE CONCAT('%', _username, '%') OR
     d.email     LIKE CONCAT('%', _username, '%')
   )
+  AND (_action   = '' OR _action   IS NULL OR a.action   = _action)
+  AND (_category = '' OR _category IS NULL OR a.category = _category)
   AND (_from_time = 0 OR a.ctime >= _from_time)
   AND (_to_time   = 0 OR a.ctime <= _to_time)
   ORDER BY a.ctime DESC

--- a/common/tables/action_log.sql
+++ b/common/tables/action_log.sql
@@ -1,7 +1,7 @@
 CREATE TABLE IF NOT EXISTS `action_log` (
   `sys_id` int(11) unsigned NOT NULL AUTO_INCREMENT,
   `uid` varchar(16) NOT NULL,
-  `action` enum('added','deleted','changed','left','removed','backup','connection') DEFAULT NULL,
+  `action` enum('added','deleted','changed','left','removed','backup','connection','grant_access','change_policy','share_link','create_workspace','invite_sent','invite_accepted') DEFAULT NULL,
   `category` enum('media','permission','member','admin','title') NOT NULL,
   `notify_to` enum('all','member','admin') NOT NULL,
   `entity_id` varchar(16) DEFAULT NULL,

--- a/hub/procedures/admin/get_hub_user_storage.sql
+++ b/hub/procedures/admin/get_hub_user_storage.sql
@@ -14,29 +14,90 @@ BEGIN
 
   SET _sort_by = IFNULL(_sort_by, 'usage_high');
 
+  -- Attribute every file in this hub to its owner_id so member totals can
+  -- reconcile with get_hub_storage_stats.hub_used_bytes. Hub members with
+  -- no files still appear (0 B). Owners who have files but are not hub
+  -- members are included so their bytes are not dropped from the roll-up.
+  DROP TEMPORARY TABLE IF EXISTS _hub_owner_usage;
+  CREATE TEMPORARY TABLE _hub_owner_usage (
+    uid VARCHAR(16) NOT NULL PRIMARY KEY,
+    used_bytes BIGINT UNSIGNED NOT NULL DEFAULT 0
+  );
+
+  INSERT INTO _hub_owner_usage (uid, used_bytes)
   SELECT
-    p.entity_id AS uid,
+    m.owner_id,
+    SUM(m.filesize)
+  FROM media m
+  WHERE m.owner_id IS NOT NULL
+    AND m.owner_id != ''
+    AND m.status NOT IN ('hidden', 'deleted')
+    AND m.category NOT IN ('folder', 'hub', 'root')
+  GROUP BY m.owner_id;
+
+  DROP TEMPORARY TABLE IF EXISTS _hub_user_rows;
+  CREATE TEMPORARY TABLE _hub_user_rows (
+    uid VARCHAR(16) NOT NULL PRIMARY KEY,
+    firstname VARCHAR(128),
+    lastname VARCHAR(128),
+    fullname VARCHAR(256),
+    email VARCHAR(256),
+    hub_permission INT UNSIGNED,
+    used_bytes BIGINT UNSIGNED NOT NULL DEFAULT 0
+  );
+
+  INSERT INTO _hub_user_rows (uid, firstname, lastname, fullname, email, hub_permission, used_bytes)
+  SELECT
+    p.entity_id,
     d.firstname,
     d.lastname,
     d.fullname,
     d.email,
-    p.permission AS hub_permission,
-    COALESCE(SUM(m.filesize), 0) AS used_bytes,
-    ROUND(COALESCE(SUM(m.filesize), 0) / 1048576, 2) AS used_mb
+    p.permission,
+    COALESCE(o.used_bytes, 0)
   FROM permission p
   INNER JOIN yp.drumate d ON d.id = p.entity_id
-  LEFT JOIN media m
-    ON m.owner_id = p.entity_id
-    AND m.status NOT IN ('hidden', 'deleted')
-    AND m.category NOT IN ('folder', 'hub', 'root')
+  LEFT JOIN _hub_owner_usage o ON o.uid = p.entity_id
   WHERE p.resource_id = '*'
-    AND p.permission  > 0
-  GROUP BY p.entity_id, d.firstname, d.lastname, d.fullname, d.email, p.permission
+    AND p.permission > 0;
+
+  INSERT INTO _hub_user_rows (uid, firstname, lastname, fullname, email, hub_permission, used_bytes)
+  SELECT
+    o.uid,
+    d.firstname,
+    d.lastname,
+    d.fullname,
+    d.email,
+    0,
+    o.used_bytes
+  FROM _hub_owner_usage o
+  LEFT JOIN yp.drumate d ON d.id = o.uid
+  WHERE o.used_bytes > 0
+    AND o.uid NOT IN (
+      SELECT p.entity_id
+      FROM permission p
+      WHERE p.resource_id = '*'
+        AND p.permission > 0
+    );
+
+  SELECT
+    uid,
+    firstname,
+    lastname,
+    fullname,
+    email,
+    hub_permission,
+    used_bytes,
+    ROUND(used_bytes / 1048576, 2) AS used_mb
+  FROM _hub_user_rows
   ORDER BY
-    CASE WHEN _sort_by = 'usage_high' THEN COALESCE(SUM(m.filesize), 0) END DESC,
-    CASE WHEN _sort_by = 'usage_low' THEN COALESCE(SUM(m.filesize), 0) END ASC,
-    d.lastname ASC
+    CASE WHEN _sort_by = 'usage_high' THEN used_bytes END DESC,
+    CASE WHEN _sort_by = 'usage_low' THEN used_bytes END ASC,
+    lastname ASC
   LIMIT _offset, _range;
+
+  DROP TEMPORARY TABLE IF EXISTS _hub_user_rows;
+  DROP TEMPORARY TABLE IF EXISTS _hub_owner_usage;
 END$
 
 DELIMITER ;

--- a/hub/procedures/admin/get_hub_user_storage.sql
+++ b/hub/procedures/admin/get_hub_user_storage.sql
@@ -11,13 +11,11 @@ BEGIN
   DECLARE _offset BIGINT;
 
   CALL pageToLimits(_page, _offset, _range);
-
   SET _sort_by = IFNULL(_sort_by, 'usage_high');
 
-  -- Attribute every file in this hub to its owner_id so member totals can
-  -- reconcile with get_hub_storage_stats.hub_used_bytes. Hub members with
-  -- no files still appear (0 B). Owners who have files but are not hub
-  -- members are included so their bytes are not dropped from the roll-up.
+  -- Attribute every file to owner_id so member totals reconcile with
+  -- get_hub_storage_stats.hub_used_bytes. Hub members with 0 B still appear;
+  -- non-member owners with files are included so bytes are not dropped.
   DROP TEMPORARY TABLE IF EXISTS _hub_owner_usage;
   CREATE TEMPORARY TABLE _hub_owner_usage (
     uid VARCHAR(16) NOT NULL PRIMARY KEY,
@@ -72,13 +70,12 @@ BEGIN
     o.used_bytes
   FROM _hub_owner_usage o
   LEFT JOIN yp.drumate d ON d.id = o.uid
+  LEFT JOIN permission p
+    ON p.entity_id = o.uid
+   AND p.resource_id = '*'
+   AND p.permission > 0
   WHERE o.used_bytes > 0
-    AND o.uid NOT IN (
-      SELECT p.entity_id
-      FROM permission p
-      WHERE p.resource_id = '*'
-        AND p.permission > 0
-    );
+    AND p.entity_id IS NULL;
 
   SELECT
     uid,

--- a/investigations/admin-console-patch-list-2026-07-08.md
+++ b/investigations/admin-console-patch-list-2026-07-08.md
@@ -1,0 +1,203 @@
+# Admin Console — prod patch runbook
+
+**Source:** đã apply + verify trên **stage** (`drumee.in`, 2026-07-08 → 2026-07-09)  
+**Branch:** `feat/admin-console-audit-filter` → PR https://github.com/drumee/schemas/pull/50  
+**Base:** `preview`
+
+---
+
+## Stage status (đã chạy)
+
+| Check | Stage (`drumee.in`) |
+|-------|---------------------|
+| yp SPs (7) | ✅ có đủ |
+| `action_log` enum `invite_sent`/`invite_accepted` | ✅ **813/813** |
+| `get_hub_user_storage` | ✅ (~445 hub DBs) |
+| `hub_get_audit_logs_window` + `_count` | ✅ (~1572 routines) |
+
+→ List dưới đây = **cùng bộ file cần chạy trên prod**.
+
+---
+
+## Prod — list file cần patch (11)
+
+### 1) `common` → mọi hub + drumate DB
+
+| # | File | Mục đích |
+|---|------|----------|
+| 1 | `common/patches/alter_action_log_add_invite_actions.sql` | ALTER enum `action_log.action` (+ `invite_sent`, `invite_accepted`) |
+| 2 | `common/procedures/action_log/hub_get_audit_logs_window.sql` | Audit log list + filter |
+| 3 | `common/procedures/action_log/hub_get_audit_logs_count.sql` | Audit log count |
+
+### 2) `yp`
+
+| # | File | Mục đích |
+|---|------|----------|
+| 4 | `yellow_page/procedures/adminpannel/member_list_stats.sql` | Pending Invites counter |
+| 5 | `yellow_page/procedures/adminpannel/member_list_hubs_by_domain.sql` | Target Resource (hub list) |
+| 6 | `yellow_page/procedures/secure_share/secure_share_guest_events_by_domain.sql` | Guest activity list + search |
+| 7 | `yellow_page/procedures/secure_share/secure_share_guest_events_by_domain_count.sql` | Guest activity count |
+| 8 | `yellow_page/procedures/adminpannel/get_org_storage_stats.sql` | TOTAL HUB STORAGE |
+| 9 | `yellow_page/procedures/adminpannel/get_org_user_storage.sql` | User Storage Distribution |
+| 10 | `yellow_page/procedures/adminpannel/get_org_user_storage_count.sql` | User storage count |
+
+### 3) `hub` → mọi hub DB
+
+| # | File | Mục đích |
+|---|------|----------|
+| 11 | `hub/procedures/admin/get_hub_user_storage.sql` | Hub user storage roll-up |
+
+### Enum `invite_sent` / `invite_accepted` — chạy cái nào?
+
+| File | Khi nào | Trên prod DB đã có `action_log` |
+|------|---------|--------------------------------|
+| **`common/patches/alter_action_log_add_invite_actions.sql` (#1)** | **Bắt buộc** | ✅ Đây là lệnh bổ sung enum (`ALTER … MODIFY`) |
+| `common/tables/action_log.sql` | Seed / DB mới | ❌ **Không chạy** — `CREATE TABLE IF NOT EXISTS` thấy bảng đã có thì **bỏ qua**, enum **không** đổi |
+| `templates/factory/*.sql` | Factory tạo DB mới | Không patch runtime |
+
+→ Muốn bổ sung enum trên prod = chạy **#1 ALTER**, không phải seed table.
+
+---
+
+## Prod — lệnh chạy
+
+```bash
+cd /path/to/schemas   # prod schemas checkout (branch đã merge / tag release)
+
+# --- 1) common (hub + drumate) ---
+node bin/patch.js --schemas=$PWD --source=common/patches/alter_action_log_add_invite_actions.sql --target=common --orphan=remove --force
+node bin/patch.js --schemas=$PWD --source=common/procedures/action_log/hub_get_audit_logs_window.sql --target=common --orphan=remove --force
+node bin/patch.js --schemas=$PWD --source=common/procedures/action_log/hub_get_audit_logs_count.sql --target=common --orphan=remove --force
+
+# --- 2) yp ---
+for f in \
+  yellow_page/procedures/adminpannel/member_list_stats.sql \
+  yellow_page/procedures/adminpannel/member_list_hubs_by_domain.sql \
+  yellow_page/procedures/secure_share/secure_share_guest_events_by_domain.sql \
+  yellow_page/procedures/secure_share/secure_share_guest_events_by_domain_count.sql \
+  yellow_page/procedures/adminpannel/get_org_storage_stats.sql \
+  yellow_page/procedures/adminpannel/get_org_user_storage.sql \
+  yellow_page/procedures/adminpannel/get_org_user_storage_count.sql
+do
+  node bin/patch.js --schemas=$PWD --source=$f --target=yp --orphan=remove --force
+done
+
+# --- 3) hub ---
+node bin/patch.js --schemas=$PWD --source=hub/procedures/admin/get_hub_user_storage.sql --target=hub --orphan=remove --force
+```
+
+### Follow-up bắt buộc sau ALTER (#1)
+
+`patch.js --target=common` **chỉ** entity `type IN ('hub','drumate')`.  
+Trên stage còn thiếu schema **orphan** + type **`organization`** → phải ALTER nốt:
+
+```bash
+# Verify còn thiếu invite enum
+mysql -N -e "
+SELECT
+  SUM(COLUMN_TYPE LIKE '%invite_sent%') AS with_invite,
+  SUM(COLUMN_TYPE NOT LIKE '%invite_sent%') AS missing,
+  COUNT(*) AS total
+FROM information_schema.COLUMNS
+WHERE TABLE_NAME='action_log' AND COLUMN_NAME='action';
+"
+
+# Nếu missing > 0: ALTER mọi schema còn thiếu
+mysql -N -e "
+SELECT TABLE_SCHEMA
+FROM information_schema.COLUMNS
+WHERE TABLE_NAME='action_log' AND COLUMN_NAME='action'
+  AND COLUMN_TYPE NOT LIKE '%invite_sent%';
+" | while read db; do
+  echo "ALTER $db"
+  mysql -e "ALTER TABLE \`$db\`.action_log MODIFY action enum(
+    'added','deleted','changed','left','removed','backup','connection',
+    'grant_access','change_policy','share_link','create_workspace',
+    'invite_sent','invite_accepted'
+  ) DEFAULT NULL;"
+done
+```
+
+### Verify sau patch (prod)
+
+```bash
+# yp
+mysql -N yp -e "
+SELECT ROUTINE_NAME FROM information_schema.ROUTINES
+WHERE ROUTINE_SCHEMA='yp' AND ROUTINE_NAME IN (
+  'member_list_stats','member_list_hubs_by_domain',
+  'secure_share_guest_events_by_domain','secure_share_guest_events_by_domain_count',
+  'get_org_storage_stats','get_org_user_storage','get_org_user_storage_count'
+);"
+
+# action_log enum — expect missing=0
+mysql -N -e "
+SELECT
+  SUM(COLUMN_TYPE LIKE '%invite_sent%') AS with_invite,
+  SUM(COLUMN_TYPE NOT LIKE '%invite_sent%') AS missing,
+  COUNT(*) AS total
+FROM information_schema.COLUMNS
+WHERE TABLE_NAME='action_log' AND COLUMN_NAME='action';
+"
+
+# hub SPs
+mysql -N -e "SELECT COUNT(*) FROM information_schema.ROUTINES WHERE ROUTINE_NAME='get_hub_user_storage';"
+mysql -N -e "SELECT COUNT(*) FROM information_schema.ROUTINES WHERE ROUTINE_NAME IN ('hub_get_audit_logs_window','hub_get_audit_logs_count');"
+```
+
+---
+
+## Feature map (QA sau prod)
+
+| Feature | Files |
+|---------|-------|
+| Pending Invites counter | #4 `member_list_stats.sql` |
+| Audit filter + Target Resource | #1–3, #5 |
+| Guest activity search | #6–7 |
+| Storage TOTAL = User Distribution | #8–10 |
+| Hub user storage roll-up | #11 |
+
+---
+
+## Enum mới → data audit: chuỗi phụ thuộc
+
+Chỉ patch SQL **không** tạo row `invite_sent` / `invite_accepted`. Cần **cả write + read**:
+
+```
+Invite UI / signup
+  → server-team hub.js | signup.js | butler.js
+      writeAudit({ action: 'invite_sent' | 'invite_accepted', category: 'member', ... })
+  → <hub_db>.hub_add_action_log (IN _action VARCHAR — không hardcode enum)
+  → INSERT action_log  ← cần cột enum đã ALTER (#1)
+  → admin-api get_audit_logs
+  → hub_get_audit_logs_window / _count  (_action = '' OR a.action = _action)
+  → admin-console audit.js filter keys invite_sent / invite_accepted
+```
+
+| Layer | Gắn enum mới? | Ghi chú |
+|-------|---------------|---------|
+| `#1` ALTER `action_log.action` | **Bắt buộc** | Không có → INSERT fail / silent audit fail |
+| `hub_add_action_log` | Không cần đổi SP | `_action VARCHAR(16)` — nhận mọi string hợp lệ với cột |
+| `hub_get_audit_logs_window` / `_count` | Không hardcode list | Filter động `a.action = _action` — FE/API truyền `invite_sent` là đủ |
+| `hub_count_high_risk_actions` | **Không** gồm invite | Chỉ `grant_access/change_policy/share_link/removed` — invite không vào High-Risk card |
+| **server-team** `hub.js` / `signup.js` / `butler.js` | **Bắt buộc deploy** | Đây mới **ghi** `invite_sent` / `invite_accepted` vào `action_log` |
+| admin-console `audit.js` | Đã có filter keys | Chỉ hiện data nếu đã có row |
+| `contact.js` `invite_sent` | Khác bảng | Ghi `contact_activity` qua `contact_log_activity` — **không** phải Admin Audit `action_log` |
+
+### Gap đã thấy trên stage (`drumee.in` / endpoint `vudangnt`)
+
+- Schema enum: ✅ 813/813
+- Runtime `/srv/drumee/runtime/server/vudangnt/service/private/hub.js`: **0** chỗ `invite_sent` (cũ hơn `main` có 6)
+- Hệ quả: invite vẫn tạo `pending_invitation` (Pending Invites count tăng), nhưng **Audit Logs không có** `invite_sent` cho đến khi deploy server-team có `writeAudit(... invite_sent/invite_accepted)`
+
+**Prod checklist thêm (ngoài 11 SQL):**
+
+1. Deploy **server-team** (ít nhất `service/private/hub.js`, `signup.js`, `butler.js`, `private/_audit.js`) có audit invite  
+2. Patch SQL #1–3 (enum + audit read SPs)  
+3. Deploy admin-console (filter UI) + admin-api nếu chưa  
+
+---
+
+## Manifest / changelog (repo)
+
+Tất cả 11 file đã có trong `patches/manifest.txt` + `patches/changelog.txt` + `CHANGELOG.md` trên branch PR #50.

--- a/patches/changelog.txt
+++ b/patches/changelog.txt
@@ -4,6 +4,8 @@
   common/procedures/action_log/hub_get_audit_logs_count.sql
   yellow_page/procedures/adminpannel/member_list_stats.sql
   yellow_page/procedures/adminpannel/member_list_hubs_by_domain.sql
+  yellow_page/procedures/secure_share/secure_share_guest_events_by_domain.sql
+  yellow_page/procedures/secure_share/secure_share_guest_events_by_domain_count.sql
   common/patches/alter_task_add_duration.sql
   common/procedures/task/task_create.sql
   common/procedures/task/task_update.sql

--- a/patches/changelog.txt
+++ b/patches/changelog.txt
@@ -1,3 +1,16 @@
+2026-07-08
+  common/patches/alter_action_log_add_invite_actions.sql
+  common/procedures/action_log/hub_get_audit_logs_window.sql
+  common/procedures/action_log/hub_get_audit_logs_count.sql
+  yellow_page/procedures/adminpannel/member_list_stats.sql
+  yellow_page/procedures/adminpannel/member_list_hubs_by_domain.sql
+  common/patches/alter_task_add_duration.sql
+  common/procedures/task/task_create.sql
+  common/procedures/task/task_update.sql
+  common/procedures/task/task_list.sql
+  common/procedures/task/task_update_status.sql
+  common/procedures/task/task_set_assignees.sql
+
 2026-07-07
   hub/procedures/channel/channel_list_messages.sql
   yellow_page/procedures/adminpannel/member_list_stats.sql

--- a/patches/changelog.txt
+++ b/patches/changelog.txt
@@ -1,3 +1,9 @@
+2026-07-09
+  yellow_page/procedures/adminpannel/get_org_storage_stats.sql
+  yellow_page/procedures/adminpannel/get_org_user_storage.sql
+  yellow_page/procedures/adminpannel/get_org_user_storage_count.sql
+  hub/procedures/admin/get_hub_user_storage.sql
+
 2026-07-08
   common/patches/alter_action_log_add_invite_actions.sql
   common/procedures/action_log/hub_get_audit_logs_window.sql
@@ -6,6 +12,8 @@
   yellow_page/procedures/adminpannel/member_list_hubs_by_domain.sql
   yellow_page/procedures/secure_share/secure_share_guest_events_by_domain.sql
   yellow_page/procedures/secure_share/secure_share_guest_events_by_domain_count.sql
+  hub/procedures/admin/get_hub_user_storage.sql
+  yellow_page/procedures/adminpannel/get_org_user_storage.sql
   common/patches/alter_task_add_duration.sql
   common/procedures/task/task_create.sql
   common/procedures/task/task_update.sql

--- a/patches/manifest.txt
+++ b/patches/manifest.txt
@@ -98,5 +98,6 @@
   yellow_page/procedures/adminpannel/member_list_hubs_by_domain.sql
   yellow_page/procedures/secure_share/secure_share_guest_events_by_domain.sql
   yellow_page/procedures/secure_share/secure_share_guest_events_by_domain_count.sql
+  yellow_page/procedures/adminpannel/get_org_user_storage_count.sql
   hub/procedures/admin/get_hub_user_storage.sql
 

--- a/patches/manifest.txt
+++ b/patches/manifest.txt
@@ -98,6 +98,8 @@
   yellow_page/procedures/adminpannel/member_list_hubs_by_domain.sql
   yellow_page/procedures/secure_share/secure_share_guest_events_by_domain.sql
   yellow_page/procedures/secure_share/secure_share_guest_events_by_domain_count.sql
+  yellow_page/procedures/adminpannel/get_org_storage_stats.sql
+  yellow_page/procedures/adminpannel/get_org_user_storage.sql
   yellow_page/procedures/adminpannel/get_org_user_storage_count.sql
   hub/procedures/admin/get_hub_user_storage.sql
 

--- a/patches/manifest.txt
+++ b/patches/manifest.txt
@@ -96,4 +96,6 @@
   common/procedures/action_log/hub_get_audit_logs_count.sql
   yellow_page/procedures/adminpannel/member_list_stats.sql
   yellow_page/procedures/adminpannel/member_list_hubs_by_domain.sql
+  yellow_page/procedures/secure_share/secure_share_guest_events_by_domain.sql
+  yellow_page/procedures/secure_share/secure_share_guest_events_by_domain_count.sql
 

--- a/patches/manifest.txt
+++ b/patches/manifest.txt
@@ -98,4 +98,5 @@
   yellow_page/procedures/adminpannel/member_list_hubs_by_domain.sql
   yellow_page/procedures/secure_share/secure_share_guest_events_by_domain.sql
   yellow_page/procedures/secure_share/secure_share_guest_events_by_domain_count.sql
+  hub/procedures/admin/get_hub_user_storage.sql
 

--- a/patches/manifest.txt
+++ b/patches/manifest.txt
@@ -85,3 +85,15 @@
   hub/procedures/channel/channel_export_count.sql
   hub/procedures/channel/channel_export_file_thread_count.sql
   common/procedures/channel/channel_search_scoped.sql
+  common/patches/alter_task_add_duration.sql
+  common/procedures/task/task_create.sql
+  common/procedures/task/task_update.sql
+  common/procedures/task/task_list.sql
+  common/procedures/task/task_update_status.sql
+  common/procedures/task/task_set_assignees.sql
+  common/patches/alter_action_log_add_invite_actions.sql
+  common/procedures/action_log/hub_get_audit_logs_window.sql
+  common/procedures/action_log/hub_get_audit_logs_count.sql
+  yellow_page/procedures/adminpannel/member_list_stats.sql
+  yellow_page/procedures/adminpannel/member_list_hubs_by_domain.sql
+

--- a/templates/factory/drumate.sql
+++ b/templates/factory/drumate.sql
@@ -35,7 +35,7 @@ DROP TABLE IF EXISTS `action_log`;
 CREATE TABLE `action_log` (
   `sys_id` int(11) unsigned NOT NULL AUTO_INCREMENT,
   `uid` varchar(16) NOT NULL,
-  `action` enum('added','deleted','changed','left','removed','backup','connection','grant_access','change_policy','share_link','create_workspace') DEFAULT NULL,
+  `action` enum('added','deleted','changed','left','removed','backup','connection','grant_access','change_policy','share_link','create_workspace','invite_sent','invite_accepted') DEFAULT NULL,
   `category` enum('media','permission','member','admin','title') NOT NULL,
   `notify_to` enum('all','member','admin') NOT NULL,
   `entity_id` varchar(16) DEFAULT NULL,

--- a/templates/factory/hub.sql
+++ b/templates/factory/hub.sql
@@ -35,7 +35,7 @@ DROP TABLE IF EXISTS `action_log`;
 CREATE TABLE `action_log` (
   `sys_id` int(11) unsigned NOT NULL AUTO_INCREMENT,
   `uid` varchar(16) NOT NULL,
-  `action` enum('added','deleted','changed','left','removed','backup','connection','grant_access','change_policy','share_link','create_workspace') DEFAULT NULL,
+  `action` enum('added','deleted','changed','left','removed','backup','connection','grant_access','change_policy','share_link','create_workspace','invite_sent','invite_accepted') DEFAULT NULL,
   `category` enum('media','permission','member','admin','title') NOT NULL,
   `notify_to` enum('all','member','admin') NOT NULL,
   `entity_id` varchar(16) DEFAULT NULL,

--- a/yellow_page/procedures/adminpannel/get_org_storage_stats.sql
+++ b/yellow_page/procedures/adminpannel/get_org_storage_stats.sql
@@ -5,23 +5,77 @@ CREATE PROCEDURE `get_org_storage_stats`(
   IN _domain_id INT(11) UNSIGNED
 )
 BEGIN
-  -- Per-hub used storage from the maintained yp.disk_usage table (keyed by
-  -- hub_id). The previous source (entity.space) is a dead column — 0 for every
-  -- hub — so the org storage breakdown read 0 B for every workspace.
-  -- hub_name: entity.ident is often NULL on freshly-created hubs, so fall back
-  -- through yp.hub.name then hubname (same chain as member_list_workspaces).
+  DECLARE _finished INT DEFAULT 0;
+  DECLARE _hub_id VARCHAR(16);
+  DECLARE _db_name VARCHAR(255) CHARACTER SET ascii;
+  DECLARE _used BIGINT UNSIGNED DEFAULT 0;
+
+  DECLARE hub_cursor CURSOR FOR
+    SELECT e.id, e.db_name
+    FROM yp.entity e
+    WHERE e.dom_id = _domain_id
+      AND e.type = 'hub'
+      AND e.status = 'active'
+      AND e.db_name IS NOT NULL
+      AND e.db_name != '';
+
+  DECLARE CONTINUE HANDLER FOR NOT FOUND SET _finished = 1;
+
+  -- Live SUM(media.filesize) per org hub so TOTAL HUB STORAGE matches
+  -- get_org_user_storage (all owners, including external collaborators).
+  DROP TEMPORARY TABLE IF EXISTS _org_hub_usage;
+  CREATE TEMPORARY TABLE _org_hub_usage (
+    hub_id VARCHAR(16) NOT NULL PRIMARY KEY,
+    hub_name VARCHAR(255),
+    used_bytes BIGINT UNSIGNED NOT NULL DEFAULT 0
+  );
+
+  INSERT INTO _org_hub_usage (hub_id, hub_name, used_bytes)
   SELECT
-    e.id AS hub_id,
-    IFNULL(IFNULL(e.ident, h.name), h.hubname) AS hub_name,
-    COALESCE(du.size, 0) AS used_bytes,
-    ROUND(COALESCE(du.size, 0) / 1048576, 2) AS used_mb
+    e.id,
+    IFNULL(IFNULL(e.ident, h.name), h.hubname),
+    0
   FROM yp.entity e
-  LEFT JOIN yp.disk_usage du ON du.hub_id = e.id
   LEFT JOIN yp.hub h ON h.id = e.id
   WHERE e.dom_id = _domain_id
     AND e.type = 'hub'
-    AND e.status = 'active'
+    AND e.status = 'active';
+
+  SET _finished = 0;
+  OPEN hub_cursor;
+  hub_loop: LOOP
+    FETCH hub_cursor INTO _hub_id, _db_name;
+    IF _finished = 1 THEN
+      LEAVE hub_loop;
+    END IF;
+
+    SET _used = 0;
+    SET @sql = CONCAT(
+      'SELECT COALESCE(SUM(m.filesize), 0) INTO @hub_used_bytes ',
+      'FROM `', _db_name, '`.media m ',
+      'WHERE m.status NOT IN (''hidden'', ''deleted'') ',
+      'AND m.category NOT IN (''folder'', ''hub'', ''root'')'
+    );
+    PREPARE stmt FROM @sql;
+    EXECUTE stmt;
+    DEALLOCATE PREPARE stmt;
+    SET _used = COALESCE(@hub_used_bytes, 0);
+
+    UPDATE _org_hub_usage
+    SET used_bytes = _used
+    WHERE hub_id = _hub_id;
+  END LOOP hub_loop;
+  CLOSE hub_cursor;
+
+  SELECT
+    hub_id,
+    hub_name,
+    used_bytes,
+    ROUND(used_bytes / 1048576, 2) AS used_mb
+  FROM _org_hub_usage
   ORDER BY used_bytes DESC;
+
+  DROP TEMPORARY TABLE IF EXISTS _org_hub_usage;
 END$
 
 DELIMITER ;

--- a/yellow_page/procedures/adminpannel/get_org_user_storage.sql
+++ b/yellow_page/procedures/adminpannel/get_org_user_storage.sql
@@ -24,25 +24,15 @@ BEGIN
   DECLARE CONTINUE HANDLER FOR NOT FOUND SET _finished = 1;
 
   CALL pageToLimits(_page, _offset, _range);
-
   SET _sort_by = IFNULL(_sort_by, 'usage_high');
 
-  -- Per-user bytes attributed by file owner_id across org workspaces only.
-  -- Matches get_org_storage_stats (sum of yp.disk_usage per hub) when every
-  -- file in those hubs is owned by a domain member. The previous source
-  -- (disk_usage(uid)) counted entire owned hubs + personal space, which
-  -- diverged from the org workspace total shown in the Storage tab.
+  -- Attribute file bytes by owner_id across org workspaces:
+  -- domain members (always listed) + external collaborators + orphan owners.
   DROP TEMPORARY TABLE IF EXISTS _org_user_usage;
   CREATE TEMPORARY TABLE _org_user_usage (
     uid VARCHAR(16) NOT NULL PRIMARY KEY,
     used_bytes BIGINT UNSIGNED NOT NULL DEFAULT 0
   );
-
-  INSERT INTO _org_user_usage (uid, used_bytes)
-  SELECT d.id, 0
-  FROM yp.drumate d
-  INNER JOIN yp.privilege p ON p.uid = d.id
-  WHERE d.domain_id = _domain_id;
 
   SET _finished = 0;
   OPEN hub_cursor;
@@ -52,52 +42,108 @@ BEGIN
       LEAVE hub_loop;
     END IF;
 
-    DROP TEMPORARY TABLE IF EXISTS _hub_slice;
-    CREATE TEMPORARY TABLE _hub_slice (
-      uid VARCHAR(16) NOT NULL PRIMARY KEY,
-      used_bytes BIGINT UNSIGNED NOT NULL DEFAULT 0
-    );
-
     SET @sql = CONCAT(
-      'INSERT INTO _hub_slice (uid, used_bytes) ',
+      'INSERT INTO _org_user_usage (uid, used_bytes) ',
       'SELECT m.owner_id, SUM(m.filesize) ',
       'FROM `', _db_name, '`.media m ',
-      'INNER JOIN yp.drumate d ON d.id = m.owner_id AND d.domain_id = ', _domain_id, ' ',
-      'WHERE m.status NOT IN (''hidden'', ''deleted'') ',
+      'WHERE m.owner_id IS NOT NULL ',
+      'AND m.owner_id != '''' ',
+      'AND m.status NOT IN (''hidden'', ''deleted'') ',
       'AND m.category NOT IN (''folder'', ''hub'', ''root'') ',
-      'GROUP BY m.owner_id'
+      'GROUP BY m.owner_id ',
+      'ON DUPLICATE KEY UPDATE ',
+      'used_bytes = used_bytes + VALUES(used_bytes)'
     );
     PREPARE stmt FROM @sql;
     EXECUTE stmt;
     DEALLOCATE PREPARE stmt;
-
-    UPDATE _org_user_usage u
-    INNER JOIN _hub_slice s ON s.uid = u.uid
-    SET u.used_bytes = u.used_bytes + s.used_bytes;
-
-    DROP TEMPORARY TABLE IF EXISTS _hub_slice;
   END LOOP hub_loop;
   CLOSE hub_cursor;
 
+  DROP TEMPORARY TABLE IF EXISTS _org_user_rows;
+  CREATE TEMPORARY TABLE _org_user_rows (
+    uid VARCHAR(16) NOT NULL PRIMARY KEY,
+    firstname VARCHAR(128),
+    lastname VARCHAR(128),
+    fullname VARCHAR(256),
+    email VARCHAR(256),
+    domain_privilege INT UNSIGNED,
+    is_external TINYINT UNSIGNED NOT NULL DEFAULT 0,
+    used_bytes BIGINT UNSIGNED NOT NULL DEFAULT 0
+  );
+
+  -- Domain members (0 B rows included for the full roster).
+  INSERT INTO _org_user_rows (
+    uid, firstname, lastname, fullname, email, domain_privilege, is_external, used_bytes
+  )
   SELECT
-    d.id AS uid,
+    d.id,
     d.firstname,
     d.lastname,
     d.fullname,
     d.email,
-    p.privilege AS domain_privilege,
-    COALESCE(u.used_bytes, 0) AS used_bytes,
-    ROUND(COALESCE(u.used_bytes, 0) / 1048576, 2) AS used_mb
+    p.privilege,
+    0,
+    COALESCE(u.used_bytes, 0)
   FROM yp.drumate d
   INNER JOIN yp.privilege p ON p.uid = d.id
   LEFT JOIN _org_user_usage u ON u.uid = d.id
-  WHERE d.domain_id = _domain_id
+  WHERE d.domain_id = _domain_id;
+
+  -- External collaborators (other domains) with files in org hubs.
+  INSERT INTO _org_user_rows (
+    uid, firstname, lastname, fullname, email, domain_privilege, is_external, used_bytes
+  )
+  SELECT
+    d.id,
+    d.firstname,
+    d.lastname,
+    d.fullname,
+    d.email,
+    0,
+    1,
+    u.used_bytes
+  FROM _org_user_usage u
+  INNER JOIN yp.drumate d ON d.id = u.uid
+  WHERE u.used_bytes > 0
+    AND d.domain_id != _domain_id;
+
+  -- Orphan owners (uid no longer in yp.drumate).
+  INSERT INTO _org_user_rows (
+    uid, firstname, lastname, fullname, email, domain_privilege, is_external, used_bytes
+  )
+  SELECT
+    u.uid,
+    NULL,
+    NULL,
+    u.uid,
+    NULL,
+    0,
+    1,
+    u.used_bytes
+  FROM _org_user_usage u
+  LEFT JOIN yp.drumate d ON d.id = u.uid
+  WHERE u.used_bytes > 0
+    AND d.id IS NULL;
+
+  SELECT
+    uid,
+    firstname,
+    lastname,
+    fullname,
+    email,
+    domain_privilege,
+    is_external,
+    used_bytes,
+    ROUND(used_bytes / 1048576, 2) AS used_mb
+  FROM _org_user_rows
   ORDER BY
-    CASE WHEN _sort_by = 'usage_high' THEN COALESCE(u.used_bytes, 0) END DESC,
-    CASE WHEN _sort_by = 'usage_low' THEN COALESCE(u.used_bytes, 0) END ASC,
-    d.lastname ASC
+    CASE WHEN _sort_by = 'usage_high' THEN used_bytes END DESC,
+    CASE WHEN _sort_by = 'usage_low' THEN used_bytes END ASC,
+    lastname ASC
   LIMIT _offset, _range;
 
+  DROP TEMPORARY TABLE IF EXISTS _org_user_rows;
   DROP TEMPORARY TABLE IF EXISTS _org_user_usage;
 END$
 

--- a/yellow_page/procedures/adminpannel/get_org_user_storage.sql
+++ b/yellow_page/procedures/adminpannel/get_org_user_storage.sql
@@ -9,16 +9,76 @@ CREATE PROCEDURE `get_org_user_storage`(
 BEGIN
   DECLARE _range BIGINT;
   DECLARE _offset BIGINT;
+  DECLARE _finished INT DEFAULT 0;
+  DECLARE _db_name VARCHAR(255) CHARACTER SET ascii;
+
+  DECLARE hub_cursor CURSOR FOR
+    SELECT e.db_name
+    FROM yp.entity e
+    WHERE e.dom_id = _domain_id
+      AND e.type = 'hub'
+      AND e.status = 'active'
+      AND e.db_name IS NOT NULL
+      AND e.db_name != '';
+
+  DECLARE CONTINUE HANDLER FOR NOT FOUND SET _finished = 1;
 
   CALL pageToLimits(_page, _offset, _range);
 
   SET _sort_by = IFNULL(_sort_by, 'usage_high');
 
-  -- Used storage = the user's maintained footprint (files in the hubs they own
-  -- + their personal space), via the canonical yp.disk_usage() function — the
-  -- same source data_usage()/disk_free()/the quota cache use. The previous
-  -- source (entity.space) is a dead column, 0 for every drumate and hub, which
-  -- made every user read 0 B used.
+  -- Per-user bytes attributed by file owner_id across org workspaces only.
+  -- Matches get_org_storage_stats (sum of yp.disk_usage per hub) when every
+  -- file in those hubs is owned by a domain member. The previous source
+  -- (disk_usage(uid)) counted entire owned hubs + personal space, which
+  -- diverged from the org workspace total shown in the Storage tab.
+  DROP TEMPORARY TABLE IF EXISTS _org_user_usage;
+  CREATE TEMPORARY TABLE _org_user_usage (
+    uid VARCHAR(16) NOT NULL PRIMARY KEY,
+    used_bytes BIGINT UNSIGNED NOT NULL DEFAULT 0
+  );
+
+  INSERT INTO _org_user_usage (uid, used_bytes)
+  SELECT d.id, 0
+  FROM yp.drumate d
+  INNER JOIN yp.privilege p ON p.uid = d.id
+  WHERE d.domain_id = _domain_id;
+
+  SET _finished = 0;
+  OPEN hub_cursor;
+  hub_loop: LOOP
+    FETCH hub_cursor INTO _db_name;
+    IF _finished = 1 THEN
+      LEAVE hub_loop;
+    END IF;
+
+    DROP TEMPORARY TABLE IF EXISTS _hub_slice;
+    CREATE TEMPORARY TABLE _hub_slice (
+      uid VARCHAR(16) NOT NULL PRIMARY KEY,
+      used_bytes BIGINT UNSIGNED NOT NULL DEFAULT 0
+    );
+
+    SET @sql = CONCAT(
+      'INSERT INTO _hub_slice (uid, used_bytes) ',
+      'SELECT m.owner_id, SUM(m.filesize) ',
+      'FROM `', _db_name, '`.media m ',
+      'INNER JOIN yp.drumate d ON d.id = m.owner_id AND d.domain_id = ', _domain_id, ' ',
+      'WHERE m.status NOT IN (''hidden'', ''deleted'') ',
+      'AND m.category NOT IN (''folder'', ''hub'', ''root'') ',
+      'GROUP BY m.owner_id'
+    );
+    PREPARE stmt FROM @sql;
+    EXECUTE stmt;
+    DEALLOCATE PREPARE stmt;
+
+    UPDATE _org_user_usage u
+    INNER JOIN _hub_slice s ON s.uid = u.uid
+    SET u.used_bytes = u.used_bytes + s.used_bytes;
+
+    DROP TEMPORARY TABLE IF EXISTS _hub_slice;
+  END LOOP hub_loop;
+  CLOSE hub_cursor;
+
   SELECT
     d.id AS uid,
     d.firstname,
@@ -26,16 +86,19 @@ BEGIN
     d.fullname,
     d.email,
     p.privilege AS domain_privilege,
-    COALESCE(disk_usage(d.id), 0) AS used_bytes,
-    ROUND(COALESCE(disk_usage(d.id), 0) / 1048576, 2) AS used_mb
+    COALESCE(u.used_bytes, 0) AS used_bytes,
+    ROUND(COALESCE(u.used_bytes, 0) / 1048576, 2) AS used_mb
   FROM yp.drumate d
   INNER JOIN yp.privilege p ON p.uid = d.id
+  LEFT JOIN _org_user_usage u ON u.uid = d.id
   WHERE d.domain_id = _domain_id
   ORDER BY
-    CASE WHEN _sort_by = 'usage_high' THEN used_bytes END DESC,
-    CASE WHEN _sort_by = 'usage_low' THEN used_bytes END ASC,
+    CASE WHEN _sort_by = 'usage_high' THEN COALESCE(u.used_bytes, 0) END DESC,
+    CASE WHEN _sort_by = 'usage_low' THEN COALESCE(u.used_bytes, 0) END ASC,
     d.lastname ASC
   LIMIT _offset, _range;
+
+  DROP TEMPORARY TABLE IF EXISTS _org_user_usage;
 END$
 
 DELIMITER ;

--- a/yellow_page/procedures/adminpannel/get_org_user_storage_count.sql
+++ b/yellow_page/procedures/adminpannel/get_org_user_storage_count.sql
@@ -5,13 +5,69 @@ CREATE PROCEDURE `get_org_user_storage_count`(
   IN _domain_id INT(11) UNSIGNED
 )
 BEGIN
-  -- Total user count for the domain — paired with get_org_user_storage so
-  -- the FE Storage tab paginator can show "Showing 1-20 of N" instead of
-  -- a page-only label. WHERE clause matches the data SP exactly.
-  SELECT COUNT(*) AS total
+  DECLARE _finished INT DEFAULT 0;
+  DECLARE _db_name VARCHAR(255) CHARACTER SET ascii;
+  DECLARE _domain_members INT UNSIGNED DEFAULT 0;
+  DECLARE _external_owners INT UNSIGNED DEFAULT 0;
+
+  DECLARE hub_cursor CURSOR FOR
+    SELECT e.db_name
+    FROM yp.entity e
+    WHERE e.dom_id = _domain_id
+      AND e.type = 'hub'
+      AND e.status = 'active'
+      AND e.db_name IS NOT NULL
+      AND e.db_name != '';
+
+  DECLARE CONTINUE HANDLER FOR NOT FOUND SET _finished = 1;
+
+  -- Count only: collect distinct owner_ids (no SUM). Matches the row set of
+  -- get_org_user_storage = domain members + external/orphan owners with files.
+  DROP TEMPORARY TABLE IF EXISTS _org_owners;
+  CREATE TEMPORARY TABLE _org_owners (
+    uid VARCHAR(16) NOT NULL PRIMARY KEY
+  );
+
+  SET _finished = 0;
+  OPEN hub_cursor;
+  hub_loop: LOOP
+    FETCH hub_cursor INTO _db_name;
+    IF _finished = 1 THEN
+      LEAVE hub_loop;
+    END IF;
+
+    SET @sql = CONCAT(
+      'INSERT IGNORE INTO _org_owners (uid) ',
+      'SELECT DISTINCT m.owner_id ',
+      'FROM `', _db_name, '`.media m ',
+      'WHERE m.owner_id IS NOT NULL ',
+      'AND m.owner_id != '''' ',
+      'AND m.status NOT IN (''hidden'', ''deleted'') ',
+      'AND m.category NOT IN (''folder'', ''hub'', ''root'')'
+    );
+    PREPARE stmt FROM @sql;
+    EXECUTE stmt;
+    DEALLOCATE PREPARE stmt;
+  END LOOP hub_loop;
+  CLOSE hub_cursor;
+
+  SELECT COUNT(*)
+  INTO _domain_members
   FROM yp.drumate d
   INNER JOIN yp.privilege p ON p.uid = d.id
   WHERE d.domain_id = _domain_id;
+
+  -- External drumates + orphan uids (not in domain roster).
+  SELECT COUNT(*)
+  INTO _external_owners
+  FROM _org_owners o
+  LEFT JOIN yp.drumate d ON d.id = o.uid
+  LEFT JOIN yp.privilege p ON p.uid = d.id AND d.domain_id = _domain_id
+  WHERE p.uid IS NULL;
+
+  SELECT (_domain_members + _external_owners) AS total;
+
+  DROP TEMPORARY TABLE IF EXISTS _org_owners;
 END$
 
 DELIMITER ;

--- a/yellow_page/procedures/adminpannel/member_list_hubs_by_domain.sql
+++ b/yellow_page/procedures/adminpannel/member_list_hubs_by_domain.sql
@@ -5,8 +5,14 @@ CREATE PROCEDURE `member_list_hubs_by_domain`(
   IN _dom_id INT
 )
 BEGIN
-  SELECT e.id, e.db_name
+  -- `name` resolved like member_list_workspaces (ident → hub.name → hubname)
+  -- so the audit aggregator can attach a display name to each hub's rows.
+  SELECT
+    e.id,
+    e.db_name,
+    IFNULL(IFNULL(e.ident, h.name), h.hubname) AS name
   FROM entity e
+  LEFT JOIN hub h ON h.id = e.id
   WHERE
     e.dom_id = _dom_id AND
     e.type = 'hub' AND

--- a/yellow_page/procedures/adminpannel/member_list_stats.sql
+++ b/yellow_page/procedures/adminpannel/member_list_stats.sql
@@ -15,7 +15,20 @@ BEGIN
     -- hub_member_stats (`permission & 16`) and the role labels. The old
     -- `privilege > 1` over-counted every write-capable member as an admin.
     SUM(CASE WHEN p.privilege & 16 THEN 1 ELSE 0 END) AS admins,
-    SUM(CASE WHEN COALESCE(d.connected, '0') = '0' AND e.status = 'active' THEN 1 ELSE 0 END) AS pending_invites,
+    (
+      -- Pending invites = emails invited to a workspace that have not joined
+      -- yet (non-expired pending_invitation rows on this domain's active hubs).
+      -- Must match the list behind the stat card (pending_invites_by_domain).
+      -- The previous "never-connected drumate" count ignored workspace invites
+      -- entirely, so inviting someone never bumped the number.
+      SELECT COUNT(*)
+      FROM pending_invitation pi
+      INNER JOIN entity he ON he.id = pi.hub_id
+      WHERE he.dom_id = _dom_id
+        AND he.type = 'hub'
+        AND he.status = 'active'
+        AND (pi.expiry_time = 0 OR pi.expiry_time > UNIX_TIMESTAMP())
+    ) AS pending_invites,
     (
       -- External guests = distinct external people who opened a secure share
       -- created by a member of this org. Mirrors secure_share_guest_events_by_domain

--- a/yellow_page/procedures/secure_share/secure_share_guest_events_by_domain.sql
+++ b/yellow_page/procedures/secure_share/secure_share_guest_events_by_domain.sql
@@ -5,13 +5,16 @@ CREATE PROCEDURE `secure_share_guest_events_by_domain`(
   IN _domain_id INT(11) UNSIGNED,
   IN _from INT(11),
   IN _to INT(11),
-  IN _page VARCHAR(32)
+  IN _page VARCHAR(32),
+  IN _search VARCHAR(512)
 )
 BEGIN
   DECLARE _range BIGINT;
   DECLARE _offset BIGINT;
 
   CALL pageToLimits(_page, _offset, _range);
+
+  SET _search = NULLIF(TRIM(IFNULL(_search, '')), '');
 
   -- Org-wide external-guest opens on secure shares: every access event on a
   -- token created by a member of the domain, EXCLUDING opens by the domain's
@@ -29,6 +32,7 @@ BEGIN
     GREATEST(0, e.last_seen_at - e.entered_at) AS duration,
     IF(t.require_email = 1 OR t.password_hash IS NOT NULL
        OR t.recipient_email IS NOT NULL, 1, 0) AS is_protected,
+    t.permission_level,
     owner.fullname AS owner_name,
     IFNULL(NULLIF(h.name, ''), h.hubname) AS workspace_name
   FROM secure_share_access_event e
@@ -42,6 +46,11 @@ BEGIN
          OR viewer.domain_id != _domain_id)
     AND (_from = 0 OR e.entered_at >= _from)
     AND (_to = 0 OR e.entered_at <= _to)
+    AND (_search IS NULL
+         OR e.recipient_email LIKE CONCAT('%', _search, '%')
+         OR owner.fullname LIKE CONCAT('%', _search, '%')
+         OR owner.email LIKE CONCAT('%', _search, '%')
+         OR IFNULL(NULLIF(h.name, ''), h.hubname) LIKE CONCAT('%', _search, '%'))
   ORDER BY e.entered_at DESC
   LIMIT _offset, _range;
 END$

--- a/yellow_page/procedures/secure_share/secure_share_guest_events_by_domain_count.sql
+++ b/yellow_page/procedures/secure_share/secure_share_guest_events_by_domain_count.sql
@@ -4,9 +4,12 @@ DROP PROCEDURE IF EXISTS `secure_share_guest_events_by_domain_count`$
 CREATE PROCEDURE `secure_share_guest_events_by_domain_count`(
   IN _domain_id INT(11) UNSIGNED,
   IN _from INT(11),
-  IN _to INT(11)
+  IN _to INT(11),
+  IN _search VARCHAR(512)
 )
 BEGIN
+  SET _search = NULLIF(TRIM(IFNULL(_search, '')), '');
+
   -- Paired count for the guest-events paginator ("Showing X-Y of N").
   -- WHERE clause matches secure_share_guest_events_by_domain exactly.
   SELECT COUNT(*) AS total
@@ -15,11 +18,17 @@ BEGIN
   INNER JOIN drumate owner
     ON owner.id = t.creator_id AND owner.domain_id = _domain_id
   LEFT JOIN drumate viewer ON viewer.id = e.actor_id
+  LEFT JOIN hub h ON h.id = t.hub_id
   WHERE (e.actor_id IS NULL
          OR viewer.domain_id IS NULL
          OR viewer.domain_id != _domain_id)
     AND (_from = 0 OR e.entered_at >= _from)
-    AND (_to = 0 OR e.entered_at <= _to);
+    AND (_to = 0 OR e.entered_at <= _to)
+    AND (_search IS NULL
+         OR e.recipient_email LIKE CONCAT('%', _search, '%')
+         OR owner.fullname LIKE CONCAT('%', _search, '%')
+         OR owner.email LIKE CONCAT('%', _search, '%')
+         OR IFNULL(NULLIF(h.name, ''), h.hubname) LIKE CONCAT('%', _search, '%'));
 END$
 
 DELIMITER ;


### PR DESCRIPTION
## Summary
- Fix `member_list_stats.pending_invites` to count non-expired `pending_invitation` rows (not never-connected drumates).
- Extend `action_log` with `invite_sent` / `invite_accepted`, plus Audit filters (`action`, `category`) and target name resolution.
- Expose hub display names in `member_list_hubs_by_domain` for Target Resource.
- Align org Storage totals: `get_org_storage_stats` / `get_org_user_storage` / `get_org_user_storage_count` attribute all workspace files by `owner_id` (domain members + external collaborators + orphan owners).
- Update `get_hub_user_storage` so hub member roll-up matches `hub_used_bytes`.
- Add prod patch runbook: `investigations/admin-console-patch-list-2026-07-08.md`.

## Companion PRs
- [server-team#80](https://github.com/drumee/server-team/pull/80) — write `invite_sent` / `invite_accepted` via `writeAudit` (`hub.js`, `butler.js`, `signup.js`). Required for Audit Logs to have invite rows after the enum ALTER.
- **admin-api** / **admin-console**: already on `preview` (no extra PR).
- **signup** (UI plugin): no change needed (server-side `signup.js` is in server-team).

## Patch files (schemas)
```bash
# yp
yellow_page/procedures/adminpannel/get_org_storage_stats.sql
yellow_page/procedures/adminpannel/get_org_user_storage.sql
yellow_page/procedures/adminpannel/get_org_user_storage_count.sql
yellow_page/procedures/adminpannel/member_list_stats.sql
yellow_page/procedures/adminpannel/member_list_hubs_by_domain.sql
yellow_page/procedures/secure_share/secure_share_guest_events_by_domain.sql
yellow_page/procedures/secure_share/secure_share_guest_events_by_domain_count.sql

# hub (all hub DBs)
hub/procedures/admin/get_hub_user_storage.sql

# common (hub + drumate)
common/patches/alter_action_log_add_invite_actions.sql
common/procedures/action_log/hub_get_audit_logs_window.sql
common/procedures/action_log/hub_get_audit_logs_count.sql
```

## Test plan
- [ ] Apply manifest / patch-from-file for yp + hub + common (see runbook)
- [ ] After ALTER, verify `action_log` enum coverage (`missing=0`), including orphan/`organization` schemas
- [ ] Deploy server-team#80; send invite → `invite_sent` row; accept → `invite_accepted`
- [ ] Pending Invites counter increases after sending an invite
- [ ] Audit tab: action filter + Target Resource for invite/member/workspace events
- [ ] Storage tab: TOTAL HUB STORAGE equals sum of User Storage Distribution (incl. External/Unknown owners)
- [ ] Hub admin storage: sum of user rows ≈ `hub_used_bytes`