### PR TITLE
feat(channel): return thread ids from channel_search

### DIFF
--- a/common/procedures/channel/channel_search.sql
+++ b/common/procedures/channel/channel_search.sql
@@ -10,6 +10,9 @@ BEGIN
   SELECT
     'message' AS result_type,
     message_id AS id,
+    message_id,
+    thread_id,
+    file_thread_id,
     author_id,
     ctime,
     SUBSTRING(message, 1, 150) AS preview


### PR DESCRIPTION
Add message_id, thread_id, file_thread_id to channel_search output so the desk topbar message-search hits can resolve their chat scope. Needs patching into all hub instances (bin/patch-from-file common/procedures/channel/channel_search.sql hub).