### PR TITLE
hotfix(changelog): explicit column list in changelog_write for nid virtual col

### DIFF
--- a/patches/changelog.txt
+++ b/patches/changelog.txt
@@ -1,3 +1,6 @@
+2026-07-09
+  yellow_page/procedures/log/changelog_write.sql
+
 2026-07-07
   hub/procedures/channel/channel_list_messages.sql
   yellow_page/procedures/adminpannel/member_list_stats.sql

--- a/templates/factory/seed/yp.sql
+++ b/templates/factory/seed/yp.sql
@@ -30185,9 +30185,8 @@ CREATE PROCEDURE `changelog_write`(
   IN _dest JSON
 )
 BEGIN
-  INSERT INTO mfs_changelog VALUES(
-    null, 
-    unix_timestamp(), 
+  INSERT INTO mfs_changelog (`timestamp`, `uid`, `hub_id`, `event`, `src`, `dest`) VALUES(
+    unix_timestamp(),
     _uid,
     _hub_id,
     _event,

--- a/yellow_page/procedures/log/changelog_write.sql
+++ b/yellow_page/procedures/log/changelog_write.sql
@@ -10,9 +10,8 @@ CREATE PROCEDURE `changelog_write`(
   IN _dest JSON
 )
 BEGIN
-  INSERT INTO mfs_changelog VALUES(
-    null, 
-    unix_timestamp(), 
+  INSERT INTO mfs_changelog (`timestamp`, `uid`, `hub_id`, `event`, `src`, `dest`) VALUES(
+    unix_timestamp(),
     _uid,
     _hub_id,
     _event,


### PR DESCRIPTION
## Problem (PROD)
`changelog_write` throws `ER_WRONG_VALUE_COUNT_ON_ROW` (1136) on every `media.*` changelog write:

```
call changelog_write(...) -> Column count doesn't match value count at row 1
```

**Root cause:** the layer-2 mfs perf change (#48) added a `nid VIRTUAL` column to `yp.mfs_changelog` (8 columns now). `changelog_write` still did a **column-less** `INSERT ... VALUES(...)` with 7 values, so the count no longer matches. A column-less INSERT must supply a value for every column position (generated columns included), so adding the virtual column broke it.

Confirmed read-only on prod: `mfs_changelog` has `nid VIRTUAL GENERATED`; the deployed SP is still the old column-less form. Preview shares the prod DB (same single `yp`).

## Fix
Explicit column list `(timestamp, uid, hub_id, event, src, dest)`:
- `id` stays AUTO_INCREMENT, `nid` stays computed (virtual)
- Output `SELECT` contract unchanged
- Behavior-preserving and robust whether or not `nid` is present

Also mirrored into the factory seed (`templates/factory/seed/yp.sql`) so a rebuilt `yp` stays correct once the migration reaches it.

## Verification (stage, mirrors prod schema)
- Old SP against an nid-bearing table → reproduced `ERROR 1136`.
- New SP → succeeds; isolated repro + a live call on the real stage `yp.mfs_changelog` (row inserted, `nid` computed, test row deleted).
- Fixed SP already applied to stage `yp`, test endpoint verified.

## Deploy
Single `yp` DB, idempotent DROP+CREATE. Prod apply is manual (Somanos/Liam). No factory concern for this SP beyond the seed sync above.