### PR TITLE
hotfix(changelog): explicit column list in changelog_write for nid virtual col (→ test)

### DIFF
--- a/patches/changelog.txt
+++ b/patches/changelog.txt
@@ -1,4 +1,5 @@
 2026-07-09
+  yellow_page/procedures/log/changelog_write.sql
   yellow_page/procedures/adminpannel/get_org_storage_stats.sql
   yellow_page/procedures/adminpannel/get_org_user_storage.sql
   yellow_page/procedures/adminpannel/get_org_user_storage_count.sql

--- a/templates/factory/seed/yp.sql
+++ b/templates/factory/seed/yp.sql
@@ -30185,9 +30185,8 @@ CREATE PROCEDURE `changelog_write`(
   IN _dest JSON
 )
 BEGIN
-  INSERT INTO mfs_changelog VALUES(
-    null, 
-    unix_timestamp(), 
+  INSERT INTO mfs_changelog (`timestamp`, `uid`, `hub_id`, `event`, `src`, `dest`) VALUES(
+    unix_timestamp(),
     _uid,
     _hub_id,
     _event,

--- a/yellow_page/procedures/log/changelog_write.sql
+++ b/yellow_page/procedures/log/changelog_write.sql
@@ -10,9 +10,8 @@ CREATE PROCEDURE `changelog_write`(
   IN _dest JSON
 )
 BEGIN
-  INSERT INTO mfs_changelog VALUES(
-    null, 
-    unix_timestamp(), 
+  INSERT INTO mfs_changelog (`timestamp`, `uid`, `hub_id`, `event`, `src`, `dest`) VALUES(
+    unix_timestamp(),
     _uid,
     _hub_id,
     _event,


### PR DESCRIPTION
Back-merge of the prod hotfix into `test` so the mainline dev branch no longer carries the buggy SP (anyone branching off `test` would otherwise inherit it).

## Context
Cherry-pick of the fix already shipped:
- **Applied to prod `yp` 2026-07-09** (verified: md5-match, live call on real prod table, alert cleared).
- **Merged to `preview`** via PR #53.

## Change
`changelog_write` used a column-less `INSERT ... VALUES(...)` (7 values). The layer-2 mfs perf change added a `nid VIRTUAL` column to `mfs_changelog` (8 cols) → `ER_WRONG_VALUE_COUNT_ON_ROW` (1136) on every `media.*` write. Fix = explicit column list `(timestamp, uid, hub_id, event, src, dest)`; `id` stays AUTO_INCREMENT, `nid` stays computed. Behavior-preserving; output SELECT unchanged. Mirrored into the factory seed + changelog.txt entry.

Scope: `yp` only. No migration (nid already present). Verified on stage (old→1136 reproduced, new→success).