### PR TITLE
fix(desk_create_hub): new hub inherits the OWNER's org domain

### DIFF
--- a/drumate/procedures/desk_create_hub.sql
+++ b/drumate/procedures/desk_create_hub.sql
@@ -1,0 +1,190 @@
+-- Deployed to every drumate DB (target: drumate). Canonical copy of the
+-- factory-template desk_create_hub carrying the domain-resolution fix —
+-- keep templates/factory/drumate.sql in sync when editing.
+DELIMITER $
+
+DROP PROCEDURE IF EXISTS `desk_create_hub`$
+CREATE PROCEDURE `desk_create_hub`(
+  IN _args JSON,
+  IN _profile JSON
+)
+BEGIN
+  DECLARE _hub_id VARCHAR(16) CHARACTER SET ascii;
+  DECLARE _hub_db VARCHAR(50) CHARACTER SET ascii;
+  DECLARE _is_wicket BOOLEAN DEFAULT 0;
+  DECLARE _default_privilege TINYINT(4);
+  DECLARE _userFilename VARCHAR(500);
+  DECLARE _domain_id INTEGER;
+  DECLARE _domain VARCHAR(500)  CHARACTER SET ascii;
+  DECLARE _reason VARCHAR(500);
+  DECLARE _icon VARCHAR(500) DEFAULT "/-/images/logo/desk.jpg";
+  DECLARE _folders JSON;
+  DECLARE _fqdn VARCHAR(1024);  
+  DECLARE _rollback BOOLEAN DEFAULT 0;   
+  DECLARE _serial INT DEFAULT 1;
+  DECLARE _hostname VARCHAR(80);
+  DECLARE _vhost VARCHAR(80);
+  DECLARE _area VARCHAR(16);
+  DECLARE _owner_id  VARCHAR(16);
+  DECLARE _description varchar(2000) DEFAULT NULL;
+  DECLARE _keywords varchar(2000) DEFAULT NULL;
+ 
+  DECLARE CONTINUE HANDLER FOR SQLEXCEPTION
+  BEGIN
+    SET _rollback = 1;  
+    GET DIAGNOSTICS CONDITION 1 @sqlstate = RETURNED_SQLSTATE, 
+    @errno = MYSQL_ERRNO, @text = MESSAGE_TEXT;
+    SET @full_error = CONCAT("ERROR ", @errno, " (", @sqlstate, "): ", @text);
+  END;
+
+  
+  SELECT IFNULL(JSON_VALUE(_args, "$.description"), "") INTO _description;
+  SELECT IFNULL(JSON_VALUE(_args, "$.keywords"), "") INTO _keywords;
+  SELECT IFNULL(JSON_VALUE(_profile, "$.is_wicket"), 0) INTO _is_wicket;
+
+  SELECT JSON_VALUE(_args, "$.filename") INTO _userFilename;
+  SELECT JSON_VALUE(_args, "$.hostname") INTO _hostname;
+  SELECT JSON_VALUE(_args, "$.owner_id") INTO _owner_id;
+  SELECT JSON_VALUE(_args, "$.domain_id") INTO _domain_id;
+  SELECT JSON_VALUE(_args, "$.domain") INTO _domain;
+  SELECT JSON_VALUE(_profile, "$.folders") INTO _folders;
+
+
+  -- The new hub belongs to its OWNER's org domain (the entity of this
+  -- drumate DB) — NOT to the vhost the caller happened to browse through.
+  -- The previous priority resolved args.domain (session vhost) first, so an
+  -- org member creating a workspace via the main vhost landed the hub in
+  -- domain 1, hiding it from every org-scoped admin surface (pending
+  -- invites, member stats, storage summary). An explicit args.domain_id
+  -- still wins (system flows); args.domain is only a last-resort hint.
+  IF _domain_id IS NULL THEN
+    SELECT e.dom_id FROM yp.entity e
+      WHERE e.db_name = DATABASE() INTO _domain_id;
+    IF _domain_id IS NULL OR _domain_id < 1 THEN
+      SELECT id FROM yp.domain WHERE `name`= _domain INTO _domain_id;
+    END IF;
+    IF _domain_id IS NULL THEN
+      SELECT 1 INTO _domain_id;
+    END IF;
+    SELECT `name` FROM yp.domain WHERE id = _domain_id INTO _domain;
+    IF _domain IS NULL THEN
+      SELECT yp.get_sysconf('domain_name' ) INTO _domain;
+    END IF;
+  END IF;
+
+  SELECT IFNULL(JSON_VALUE(_args, "$.area"), "private") INTO _area;
+  SELECT CASE _area
+    WHEN 'public' THEN 3
+    WHEN 'dmz' THEN 3
+    WHEN 'share' THEN 3
+    WHEN 'private' THEN 7 
+    ELSE 0 
+  END INTO _default_privilege;
+
+  SELECT JSON_REMOVE(_profile, "$.folders") INTO _profile;
+  SELECT yp.ensure_vhost(_args) INTO _fqdn;
+
+  START TRANSACTION;
+  
+  CALL yp.pickupEntity('hub', _hub_id, _hub_db);
+  IF _fqdn IS NULL OR _userFilename IS NULL OR _hostname IS NULL THEN
+    SELECT 1 INTO _rollback;
+    SELECT CONCAT("Unproper environment ", 
+      IFNULL(_fqdn, "_fqdn"), " ", 
+      IFNULL(_userFilename, "_userFilename"), " ", 
+      IFNULL(_hostname, "__hostname")
+    ) INTO _reason;
+  END IF;
+
+  IF _hub_db IS NULL OR _hub_id IS NULL THEN 
+    SELECT 1 INTO _rollback;
+    SELECT CONCAT("Pool ", _area, " is empty. Considerer runing factory") INTO _reason;
+  END IF;
+
+  IF _default_privilege = 0 THEN 
+    SELECT 1 INTO _rollback;
+    SELECT CONCAT("Area ", _area, " is not allowed") INTO _reason;
+  END IF;
+
+  SELECT conf_value FROM yp.sys_conf WHERE conf_key='icon' INTO _icon;
+  UPDATE yp.entity SET 
+    area=_area, 
+    status='active', 
+    dom_id =_domain_id,
+    icon=_icon,
+    settings=json_set(settings, "$.default_privilege", _default_privilege)
+  WHERE id=_hub_id;
+
+  INSERT INTO yp.vhost VALUES (null, _fqdn, _hub_id, _domain_id);
+
+  SELECT sys_id FROM yp.vhost WHERE fqdn=_fqdn INTO _serial;
+
+  SELECT JSON_SET(_profile, "$.name", _userFilename) INTO _profile;
+  INSERT INTO yp.hub (
+    `id`, `owner_id`, `origin_id`, 
+    `name`, `serial`, `description`, `keywords`,
+    `hubname`, `domain_id`, `profile`)
+  VALUES (
+    _hub_id, _owner_id, _owner_id, 
+    _userFilename, _serial, _description, _keywords,
+    _hub_id, _domain_id, _profile); 
+
+  CALL join_hub(_hub_id);
+  UPDATE media SET user_filename=_userFilename WHERE id=_hub_id;
+  CALL permission_grant(_hub_id, _owner_id, 0, 63, 'system', '');
+  SET @s = CONCAT("CALL `", _hub_db, "`.permission_grant('*', ?, 0, 63, 'system', '')");
+  PREPARE stmt FROM @s;
+  EXECUTE stmt USING _owner_id;
+  DEALLOCATE PREPARE stmt;
+
+  
+  IF _is_wicket AND _area = 'dmz' THEN 
+    UPDATE IGNORE yp.hub SET serial = 0 WHERE id = _hub_id;
+    SET @s = CONCAT("UPDATE media SET status='hidden' WHERE id=", QUOTE(_hub_id));
+    PREPARE stmt2 FROM @s;
+    EXECUTE stmt2;
+    DEALLOCATE PREPARE stmt2;
+  END IF; 
+
+
+  SELECT IF(_area='public', 3, 0) INTO @permission;
+
+  SET @s = CONCAT("CALL `", 
+    _hub_db, 
+    "`.permission_grant('*', '*', 0, ", @permission, ", 'system', '')"
+  );
+
+  PREPARE stmt FROM @s;
+  EXECUTE stmt;
+  DEALLOCATE PREPARE stmt;
+  
+  IF _folders IS NOT NULL THEN 
+    SET @s = CONCAT("CALL `", _hub_db,"`.mfs_init_folders(?, 0)");
+    PREPARE stmt FROM @s;
+    EXECUTE stmt USING _folders;
+    DEALLOCATE PREPARE stmt;
+  END IF;
+
+  SET @s = CONCAT("CALL `", _hub_db,"`.mfs_hub_chat_init();");
+  PREPARE stmt FROM @s;
+  EXECUTE stmt;
+  DEALLOCATE PREPARE stmt;
+
+  SET @s = CONCAT("CALL `", _hub_db,"`.mfs_trash_init();");
+  PREPARE stmt FROM @s;
+  EXECUTE stmt;
+  DEALLOCATE PREPARE stmt;
+
+
+  SELECT *, 0 as failed, _default_privilege default_privilege 
+    FROM yp.entity WHERE db_name=_hub_db;
+
+  IF _rollback THEN
+    ROLLBACK;
+    SELECT 1 as failed, IFNULL(_reason, @full_error) AS reason;
+  ELSE
+    COMMIT;
+  END IF;
+END$
+
+DELIMITER ;

--- a/patches/changelog.txt
+++ b/patches/changelog.txt
@@ -668,7 +668,7 @@
   drumate/procedures/mfs_mark_all_read.sql
 
 2025-12-12
-  drumate/procedures/desk/desk_create_hub.sql
+  drumate/procedures/desk_create_hub.sql
 
 2025-12-11
   drumate/procedures/mfs_get_unread_count.sql

--- a/patches/manifest.txt
+++ b/patches/manifest.txt
@@ -93,14 +93,7 @@
   common/procedures/task/task_update_status.sql
   common/procedures/task/task_set_assignees.sql
   common/patches/alter_action_log_add_invite_actions.sql
-  common/procedures/action_log/hub_get_audit_logs_window.sql
-  common/procedures/action_log/hub_get_audit_logs_count.sql
-  yellow_page/procedures/adminpannel/member_list_stats.sql
   yellow_page/procedures/adminpannel/member_list_hubs_by_domain.sql
-  yellow_page/procedures/secure_share/secure_share_guest_events_by_domain.sql
-  yellow_page/procedures/secure_share/secure_share_guest_events_by_domain_count.sql
-  yellow_page/procedures/adminpannel/get_org_storage_stats.sql
-  yellow_page/procedures/adminpannel/get_org_user_storage.sql
   yellow_page/procedures/adminpannel/get_org_user_storage_count.sql
   hub/procedures/admin/get_hub_user_storage.sql
   common/procedures/channel/channel_search.sql
@@ -114,10 +107,6 @@
   common/procedures/mfs/versioning/file_version_purge.sql
   yellow_page/procedures/adminpannel/get_hub_stale_files.sql
   yellow_page/procedures/adminpannel/get_user_storage_files.sql
-  yellow_page/procedures/adminpannel/pending_invites_by_domain.sql
-  yellow_page/procedures/adminpannel/member_list_stats.sql
-  yellow_page/procedures/adminpannel/get_org_user_storage.sql
-  hub/procedures/admin/hub_member_stats.sql
   common/patches/alter_task_health_metrics.sql
   common/tables/task_activity.sql
   common/procedures/task/task_activity_log.sql
@@ -129,3 +118,4 @@
   common/procedures/task/task_column_update.sql
   common/procedures/task/task_column_delete.sql
   common/procedures/task/task_column_get.sql
+  drumate/procedures/desk_create_hub.sql

--- a/templates/factory/drumate.sql
+++ b/templates/factory/drumate.sql
@@ -9986,14 +9986,21 @@ BEGIN
   SELECT JSON_VALUE(_profile, "$.folders") INTO _folders;
 
 
-  IF _domain_id IS NULL THEN 
-    IF _domain IS NULL THEN 
-      SELECT d.id, d.name FROM yp.domain d INNER JOIN yp.entity e ON d.id=e.dom_id 
-        WHERE e.db_name = DATABASE() INTO _domain_id, _domain;
+  -- The new hub belongs to its OWNER's org domain (the entity of this
+  -- drumate DB) — NOT to the vhost the caller happened to browse through.
+  -- An explicit args.domain_id still wins; args.domain is a last-resort hint.
+  -- (Kept in sync with drumate/procedures/desk_create_hub.sql.)
+  IF _domain_id IS NULL THEN
+    SELECT e.dom_id FROM yp.entity e
+      WHERE e.db_name = DATABASE() INTO _domain_id;
+    IF _domain_id IS NULL OR _domain_id < 1 THEN
+      SELECT id FROM yp.domain WHERE `name`= _domain INTO _domain_id;
     END IF;
-    SELECT id FROM yp.domain WHERE `name`= _domain INTO _domain_id;
     IF _domain_id IS NULL THEN
       SELECT 1 INTO _domain_id;
+    END IF;
+    SELECT `name` FROM yp.domain WHERE id = _domain_id INTO _domain;
+    IF _domain IS NULL THEN
       SELECT yp.get_sysconf('domain_name' ) INTO _domain;
     END IF;
   END IF;


### PR DESCRIPTION
## Summary
- A workspace created while the user browsed through a **different vhost** (e.g. an org-Bibi member on the main `drumee.in` endpoint) resolved `dom_id` from the **session vhost** and landed in domain 1. Every org-scoped admin surface filters `entity.dom_id` (`pending_invites_by_domain`, `member_list_stats`, `get_workspace_storage_summary`...), so the workspace **and its pending invites became invisible** in the admin console (reported: "invite khong thay trong member list, count khong tang").
- `desk_create_hub` now resolves the domain from the **owner entity** (`SELECT dom_id FROM yp.entity WHERE db_name = DATABASE()`); an explicit `args.domain_id` still wins and `args.domain` is a last-resort hint.
- Canonical patch copy added at `drumate/procedures/desk_create_hub.sql` (**target: drumate** — applies to every drumate DB) and the factory template `templates/factory/drumate.sql` updated in sync. Registered in `patches/manifest.txt` + `patches/changelog.txt` (also fixed a wrong `desk/` path in the existing changelog entry; manifest de-duplicated repeated lines).

## Deploy notes (per env)
1. `sudo bin/patch-from-file drumate/procedures/desk_create_hub.sql drumate`
2. One-off backfill for hubs created before the fix:
```sql
UPDATE entity e JOIN hub h ON h.id=e.id JOIN drumate d ON d.id=h.owner_id
SET e.dom_id = d.domain_id
WHERE e.type='hub' AND e.status='active' AND e.dom_id != d.domain_id;
UPDATE vhost v JOIN hub h ON h.id=v.id JOIN drumate d ON d.id=h.owner_id JOIN entity e ON e.id=h.id
SET v.dom_id = d.domain_id
WHERE e.type='hub' AND e.status='active' AND v.dom_id != d.domain_id;
```

## Test plan
- [x] Staging (drumee.in): proc patched across ~250 drumate DBs; backfill fixed 7 mismatched hubs (incl. "Drumee Growth + MKT")
- [x] Repro flow re-verified: invite random email into "Drumee Growth + MKT" -> admin console Member tab now shows **Pending Invites 20** and the invite row in Active Directory
- [x] `CALL pending_invites_by_domain(2, ...)` returns the invite with the correct workspace name

🤖 Generated with [Claude Code](https://claude.com/claude-code)
