### PR TITLE
hotfix(notifications): task-mention feed proc + anonymous share-open dismiss fix

### DIFF
--- a/patches/changelog.txt
+++ b/patches/changelog.txt
@@ -1,3 +1,6 @@
+2026-07-15 (notification panel — task @-mentions in the chronological feed under Unread ON)
+  yellow_page/procedures/contact/contact_task_mention_unread.sql
+
 2026-07-13 (billing cancel — org lockout fix + webhook retry + usage-cache reseed)
   yellow_page/procedures/subscription/payment_clear_entitlement.sql
   yellow_page/procedures/subscription/stripe_event_delete.sql

--- a/patches/changelog.txt
+++ b/patches/changelog.txt
@@ -1,5 +1,6 @@
-2026-07-15 (notification panel — task @-mentions in the chronological feed under Unread ON)
+2026-07-15 (notification panel — task @-mentions in the chronological feed under Unread ON; fix anonymous share-open dismiss persistence)
   yellow_page/procedures/contact/contact_task_mention_unread.sql
+  yellow_page/procedures/secure_share/secure_share_mark_open_seen.sql
 
 2026-07-13 (billing cancel — org lockout fix + webhook retry + usage-cache reseed)
   yellow_page/procedures/subscription/payment_clear_entitlement.sql

--- a/yellow_page/procedures/contact/contact_task_mention_unread.sql
+++ b/yellow_page/procedures/contact/contact_task_mention_unread.sql
@@ -1,0 +1,51 @@
+-- File: schemas/yellow_page/procedures/contact/contact_task_mention_unread.sql
+-- Purpose: Return the caller's UNDISMISSED task_mention activity rows so the
+-- activity panel can merge them into the Unread feed (which otherwise only
+-- carries MFS events, hiding task-mention notifications under Unread ON).
+-- Mirrors contact_task_assigned_unread exactly (event = 'task_mention'); columns
+-- match activity_get_feed_all's contact branch so a merged row is
+-- indistinguishable from the same row under Unread OFF.
+
+DELIMITER $
+
+DROP PROCEDURE IF EXISTS `contact_task_mention_unread`$
+
+CREATE PROCEDURE `contact_task_mention_unread`(
+  IN _user_id VARCHAR(16)
+)
+BEGIN
+  SELECT
+    c.id,
+    c.timestamp,
+    c.uid,
+    c.event,
+    'contact' AS event_type,
+    JSON_OBJECT(
+      'uid', c.uid,
+      'email', d1.email,
+      'fullname', d1.fullname
+    ) AS src,
+    JSON_OBJECT(
+      'uid', c.target_uid,
+      'email', d2.email,
+      'fullname', d2.fullname
+    ) AS dest,
+    c.data,
+    0 AS is_read,
+    d1.firstname,
+    d1.lastname,
+    d1.fullname,
+    NULL AS hub_id,
+    NULL AS hub_db_name
+  FROM yp.contact_activity c
+  LEFT JOIN yp.drumate d1 ON c.uid = d1.id
+  LEFT JOIN yp.drumate d2 ON c.target_uid = d2.id
+  WHERE c.target_uid = _user_id
+    AND c.event = 'task_mention'
+    AND c.dismissed_at IS NULL
+    AND c.uid <> _user_id
+  ORDER BY c.timestamp DESC
+  LIMIT 50;
+END$
+
+DELIMITER ;

--- a/yellow_page/procedures/secure_share/secure_share_mark_open_seen.sql
+++ b/yellow_page/procedures/secure_share/secure_share_mark_open_seen.sql
@@ -12,13 +12,20 @@ BEGIN
   -- the caller's own shares (t.creator_id = _creator_id) so one creator can never
   -- mark another creator's events. Marks the whole (token, recipient) group; a
   -- later re-open (newer last_seen_at) naturally resurfaces it as unread.
+  -- Recipient match treats '' and NULL as the same "no recipient" (anonymous /
+  -- public opens). The server's await_proc converts a JS null arg to '' before
+  -- the CALL, so an anonymous dismiss arrives as _recipient_email='' — the old
+  -- `_recipient_email IS NULL` branch therefore never matched anonymous rows, so
+  -- they were never marked seen and reappeared on reload. NULLIF(...,'')
+  -- collapses ''→NULL and <=> is the NULL-safe equality. Per-recipient scoping is
+  -- preserved: an email matches only its own rows; anonymous matches only the
+  -- no-recipient rows (clicking one does not clear the other).
   UPDATE secure_share_access_event e
   JOIN secure_share_token t ON t.id = e.token_id
   SET e.creator_seen_at = UNIX_TIMESTAMP()
   WHERE t.creator_id = _creator_id
     AND e.token_id = _token_id
-    AND (e.recipient_email = _recipient_email
-         OR (_recipient_email IS NULL AND e.recipient_email IS NULL));
+    AND NULLIF(e.recipient_email, '') <=> NULLIF(_recipient_email, '');
 END$
 
 DELIMITER ;


### PR DESCRIPTION
Schemas side of the notification hotfix (branched off preview, carries ONLY these 2 yp procs + changelog).

- **NEW `contact_task_mention_unread`** — returns the caller's undismissed task_mention activity rows so the feed can show task @-mentions under Unread ON (mirrors contact_task_assigned_unread, event='task_mention'). Additive, read-only, non-breaking.
- **`secure_share_mark_open_seen` (fix)** — anonymous 'Someone opened' notifications never persisted their dismiss: await_proc converts a JS null arg to '' before the CALL, so the proc's `IS NULL` recipient branch never matched anonymous rows. Match with `NULLIF(recipient_email,'') <=> NULLIF(_recipient_email,'')` so ''/NULL collapse to the same no-recipient group. Per-recipient scoping + the creator_id security scope are unchanged.

Both applied + verified on the stage yp DB. Apply order to prod yp: contact_task_mention_unread + secure_share_mark_open_seen, before the server deploy.