### PR TITLE
feat(task): customizable columns (is_done + reorder) + column-watch s…

### DIFF
--- a/common/patches/alter_task_column_add_is_done.sql
+++ b/common/patches/alter_task_column_add_is_done.sql
@@ -1,0 +1,22 @@
+-- Add is_done flag to task_column (idempotent). A column with is_done = 1 is a
+-- "completed" column: tasks in it are treated as done, which drives
+-- completed_at stamping and the Project Health completed/overdue stats. This
+-- replaces the previous hardcoded reliance on the literal status key 'complete',
+-- so the four built-in columns can now be renamed / recoloured / reordered /
+-- deleted like any custom column without breaking completion tracking.
+SET @c := (
+  SELECT COUNT(*) FROM information_schema.COLUMNS
+   WHERE TABLE_SCHEMA = DATABASE()
+     AND TABLE_NAME  = 'task_column'
+     AND COLUMN_NAME = 'is_done'
+);
+SET @s := IF(
+  @c = 0,
+  'ALTER TABLE task_column ADD COLUMN is_done TINYINT(1) NOT NULL DEFAULT 0 AFTER position',
+  'DO 0'
+);
+PREPARE st FROM @s; EXECUTE st; DEALLOCATE PREPARE st;
+
+-- Backfill: an already-seeded built-in 'complete' column (from before this flag
+-- existed) must become the done column so existing boards keep working.
+UPDATE task_column SET is_done = 1 WHERE id = 'complete' AND is_done = 0;

--- a/common/procedures/task/task_column_delete.sql
+++ b/common/procedures/task/task_column_delete.sql
@@ -5,18 +5,31 @@ CREATE PROCEDURE `task_column_delete`(
 )
 BEGIN
   DECLARE _moved INT DEFAULT 0;
+  DECLARE _nid VARCHAR(16) DEFAULT NULL;
+  DECLARE _fallback VARCHAR(16) DEFAULT NULL;
 
-  -- Tasks living in the deleted column fall back to the built-in 'todo'
-  -- column (never lose tasks). Report how many moved so the client can
-  -- refresh its task list when non-zero.
-  UPDATE task
-     SET status = 'todo',
-         mtime  = UNIX_TIMESTAMP()
-   WHERE status = _id;
-  SET _moved = ROW_COUNT();
+  SELECT nid INTO _nid FROM task_column WHERE id = _id;
+
+  -- Re-home this column's tasks onto the first surviving column of the SAME
+  -- scope (board order), so deleting any column — built-in or custom — never
+  -- orphans a task. (Previously tasks were force-moved to the literal 'todo';
+  -- that breaks once 'todo' itself is deletable.)
+  SELECT id INTO _fallback
+    FROM task_column
+   WHERE id <> _id AND nid <=> _nid
+   ORDER BY position, ctime
+   LIMIT 1;
+
+  IF _fallback IS NOT NULL THEN
+    UPDATE task
+       SET status = _fallback,
+           mtime  = UNIX_TIMESTAMP()
+     WHERE status = _id AND nid <=> _nid;
+    SET _moved = ROW_COUNT();
+  END IF;
 
   DELETE FROM task_column WHERE id = _id;
 
-  SELECT ROW_COUNT() AS affected, _id AS id, _moved AS moved_tasks;
+  SELECT ROW_COUNT() AS affected, _id AS id, _moved AS moved_tasks, _fallback AS moved_to;
 END$
 DELIMITER ;

--- a/common/procedures/task/task_column_get.sql
+++ b/common/procedures/task/task_column_get.sql
@@ -4,9 +4,9 @@ CREATE PROCEDURE `task_column_get`(
   IN _id VARCHAR(16)
 )
 BEGIN
-  -- Existence/lookup check used by the task service to validate a custom
-  -- status key before writing it onto a task.
-  SELECT id, nid, name, theme, position, ctime, mtime
+  -- Existence/lookup check used by the task service to validate a status key
+  -- and to read its is_done flag (completion is column-driven).
+  SELECT id, nid, name, theme, position, is_done, ctime, mtime
     FROM task_column
    WHERE id = _id;
 END$

--- a/common/procedures/task/task_column_list.sql
+++ b/common/procedures/task/task_column_list.sql
@@ -4,9 +4,30 @@ CREATE PROCEDURE `task_column_list`(
   IN _nid VARCHAR(16)
 )
 BEGIN
-  -- Custom columns for one folder scope, in board order. Built-in columns are
-  -- implicit client-side and always precede these.
-  SELECT id, nid, name, theme, position, ctime, mtime
+  DECLARE _init INT DEFAULT 0;
+  DECLARE _now INT DEFAULT UNIX_TIMESTAMP();
+  DECLARE _sk VARCHAR(16) DEFAULT IFNULL(_nid, '');
+
+  -- Initialize-once: the FIRST time a folder scope's board is opened, seed the
+  -- four built-in columns as real rows so every board always starts with the
+  -- defaults. The scope is then recorded in task_column_init and never seeded
+  -- again — so the user's renames / recolours / reorders / DELETES all persist
+  -- (a deleted built-in must NOT come back on the next open). Their ids ARE the
+  -- canonical status keys, so pre-existing tasks still match; 'complete' is
+  -- flagged is_done = 1 so completion tracking follows the column, not a label.
+  SELECT COUNT(*) INTO _init FROM task_column_init WHERE scope_key = _sk;
+  IF _init = 0 THEN
+    -- Make room so the built-ins lead any columns a folder already had.
+    UPDATE task_column SET position = position + 4 WHERE nid <=> _nid;
+    INSERT IGNORE INTO task_column (id, nid, name, theme, position, is_done, ctime, mtime) VALUES
+      ('todo',        _nid, 'To do',       'default', 0, 0, _now, _now),
+      ('in_progress', _nid, 'In progress', 'purple',  1, 0, _now, _now),
+      ('to_review',   _nid, 'To review',   'orange',  2, 0, _now, _now),
+      ('complete',    _nid, 'Complete',    'green',   3, 1, _now, _now);
+    INSERT INTO task_column_init (scope_key, ctime) VALUES (_sk, _now);
+  END IF;
+
+  SELECT id, nid, name, theme, position, is_done, ctime, mtime
     FROM task_column
    WHERE nid <=> _nid
    ORDER BY position, ctime;

--- a/common/procedures/task/task_column_reorder.sql
+++ b/common/procedures/task/task_column_reorder.sql
@@ -1,0 +1,23 @@
+DELIMITER $
+DROP PROCEDURE IF EXISTS `task_column_reorder`$
+CREATE PROCEDURE `task_column_reorder`(
+  IN _nid VARCHAR(16),
+  IN _order TEXT
+)
+BEGIN
+  -- Persist a drag-reorder of custom columns. _order is the comma-separated
+  -- column ids in their new left-to-right order; each column's position is set
+  -- to its index in that list (FIND_IN_SET is 1-based). Scoped to the folder so
+  -- one folder's reorder can't touch another's rows.
+  UPDATE task_column
+     SET position = FIND_IN_SET(id, _order),
+         mtime = UNIX_TIMESTAMP()
+   WHERE nid <=> _nid
+     AND FIND_IN_SET(id, _order) > 0;
+
+  SELECT id, nid, name, theme, position, ctime, mtime
+    FROM task_column
+   WHERE nid <=> _nid
+   ORDER BY position, ctime;
+END$
+DELIMITER ;

--- a/common/procedures/task/task_column_watch_list.sql
+++ b/common/procedures/task/task_column_watch_list.sql
@@ -1,0 +1,15 @@
+-- List the column keys a user is subscribed to within one folder, so the
+-- board can render each column's bell in its on/off state.
+DELIMITER $
+DROP PROCEDURE IF EXISTS `task_column_watch_list`$
+CREATE PROCEDURE `task_column_watch_list`(
+  IN _uid VARCHAR(16),
+  IN _nid VARCHAR(16)
+)
+BEGIN
+  SELECT column_key
+    FROM task_column_watch
+   WHERE uid = _uid
+     AND nid = IFNULL(NULLIF(_nid, ''), '0');
+END$
+DELIMITER ;

--- a/common/procedures/task/task_column_watch_set.sql
+++ b/common/procedures/task/task_column_watch_set.sql
@@ -1,0 +1,16 @@
+-- Subscribe a user to change-notifications for one column of one folder.
+-- Idempotent: re-subscribing is a no-op (INSERT IGNORE on the composite key).
+DELIMITER $
+DROP PROCEDURE IF EXISTS `task_column_watch_set`$
+CREATE PROCEDURE `task_column_watch_set`(
+  IN _uid VARCHAR(16),
+  IN _nid VARCHAR(16),
+  IN _column_key VARCHAR(32)
+)
+BEGIN
+  IF _uid IS NOT NULL AND _uid <> '' AND _column_key IS NOT NULL AND _column_key <> '' THEN
+    INSERT IGNORE INTO task_column_watch (uid, nid, column_key, ctime)
+    VALUES (_uid, IFNULL(NULLIF(_nid, ''), '0'), _column_key, UNIX_TIMESTAMP());
+  END IF;
+END$
+DELIMITER ;

--- a/common/procedures/task/task_column_watch_unset.sql
+++ b/common/procedures/task/task_column_watch_unset.sql
@@ -1,0 +1,15 @@
+-- Unsubscribe a user from a column's change-notifications.
+DELIMITER $
+DROP PROCEDURE IF EXISTS `task_column_watch_unset`$
+CREATE PROCEDURE `task_column_watch_unset`(
+  IN _uid VARCHAR(16),
+  IN _nid VARCHAR(16),
+  IN _column_key VARCHAR(32)
+)
+BEGIN
+  DELETE FROM task_column_watch
+   WHERE uid = _uid
+     AND nid = IFNULL(NULLIF(_nid, ''), '0')
+     AND column_key = _column_key;
+END$
+DELIMITER ;

--- a/common/procedures/task/task_column_watchers.sql
+++ b/common/procedures/task/task_column_watchers.sql
@@ -1,0 +1,15 @@
+-- Resolve the uids subscribed to a given column of a given folder. The server
+-- uses this to fan a task-change notification out to that column's watchers.
+DELIMITER $
+DROP PROCEDURE IF EXISTS `task_column_watchers`$
+CREATE PROCEDURE `task_column_watchers`(
+  IN _nid VARCHAR(16),
+  IN _column_key VARCHAR(32)
+)
+BEGIN
+  SELECT uid
+    FROM task_column_watch
+   WHERE nid = IFNULL(NULLIF(_nid, ''), '0')
+     AND column_key = _column_key;
+END$
+DELIMITER ;

--- a/common/procedures/task/task_update_status.sql
+++ b/common/procedures/task/task_update_status.sql
@@ -7,10 +7,17 @@ CREATE PROCEDURE `task_update_status`(
 BEGIN
   DECLARE _rank INT DEFAULT 0;
   DECLARE _nid VARCHAR(16) DEFAULT NULL;
+  DECLARE _done TINYINT DEFAULT 0;
 
   -- Resolve the task's folder so the destination-column rank is computed
   -- within the same folder, not across the whole hub.
   SELECT nid INTO _nid FROM task WHERE id = _id;
+
+  -- Is the destination a "done" column? Completion is now driven by the
+  -- column's is_done flag, not the literal 'complete' key — so a renamed or
+  -- user-created done column still stamps completed_at correctly.
+  SELECT COALESCE(MAX(is_done), 0) INTO _done
+    FROM task_column WHERE id = _status;
 
   -- Place task at the bottom of the destination (folder, status) column.
   SELECT IFNULL(MAX(rank), 0) + 1
@@ -20,13 +27,13 @@ BEGIN
      AND nid <=> _nid
      AND id <> _id;
 
-  -- Stamp completed_at when entering 'complete'; clear it when leaving.
+  -- Stamp completed_at when entering a done column; clear it when leaving.
   -- A re-complete refreshes the timestamp so cycle-time reflects the latest pass.
   UPDATE task
      SET status = _status,
          rank   = _rank,
          mtime  = UNIX_TIMESTAMP(),
-         completed_at = IF(_status = 'complete', UNIX_TIMESTAMP(), 0)
+         completed_at = IF(_done = 1, UNIX_TIMESTAMP(), 0)
    WHERE id = _id;
 
   SELECT

--- a/common/tables/task_column_init.sql
+++ b/common/tables/task_column_init.sql
@@ -1,0 +1,12 @@
+-- Marks a task folder scope as "columns initialized". The first time a scope's
+-- board is opened, task_column_list seeds the four built-in columns as real
+-- rows and records the scope here, so it is NEVER auto-seeded again. That lets
+-- the built-ins be renamed / recoloured / reordered / DELETED and have those
+-- changes persist (without a marker, a deleted built-in would just reappear on
+-- the next open). scope_key = the folder nid, or '' for the workspace root
+-- (NULL nid can't be a primary key).
+CREATE TABLE IF NOT EXISTS `task_column_init` (
+  `scope_key` VARCHAR(16) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL,
+  `ctime`     INT(11) NOT NULL DEFAULT 0,
+  PRIMARY KEY (`scope_key`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;

--- a/common/tables/task_column_watch.sql
+++ b/common/tables/task_column_watch.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS task_column_watch (
+  uid varchar(16) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL,
+  -- Folder scope. '0' = workspace root (built-in column keys like 'todo' are
+  -- only unique within a folder, so the watch must be folder-scoped).
+  nid varchar(16) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL DEFAULT '0',
+  -- Either a built-in status string ('todo', 'in_progress', …) or a custom
+  -- task_column.id. No FK — built-ins have no task_column row.
+  column_key varchar(32) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL,
+  ctime int(11) NOT NULL DEFAULT 0,
+  PRIMARY KEY (uid, nid, column_key),
+  KEY idx_col (nid, column_key)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;

--- a/patches/manifest.txt
+++ b/patches/manifest.txt
@@ -129,6 +129,15 @@
   common/procedures/task/task_column_update.sql
   common/procedures/task/task_column_delete.sql
   common/procedures/task/task_column_get.sql
+  common/patches/alter_task_column_add_is_done.sql
+  common/tables/task_column_init.sql
+  common/procedures/task/task_column_reorder.sql
+  common/tables/task_column_watch.sql
+  common/procedures/task/task_column_watch_set.sql
+  common/procedures/task/task_column_watch_unset.sql
+  common/procedures/task/task_column_watch_list.sql
+  common/procedures/task/task_column_watchers.sql
+  yellow_page/procedures/contact/contact_task_column_change_unread.sql
   yellow_page/procedures/subscription/payment_clear_entitlement.sql
   yellow_page/procedures/subscription/stripe_event_delete.sql
   yellow_page/procedures/subscription/payment_apply_entitlement.sql

--- a/yellow_page/procedures/contact/contact_log_activity.sql
+++ b/yellow_page/procedures/contact/contact_log_activity.sql
@@ -19,6 +19,8 @@ CREATE PROCEDURE `contact_log_activity`(
 BEGIN
   DECLARE _hub_id VARCHAR(16) CHARACTER SET ascii;
   DECLARE _task_id VARCHAR(16) CHARACTER SET ascii;
+  DECLARE _col_key VARCHAR(32) CHARACTER SET ascii;
+  DECLARE _col_nid VARCHAR(16) CHARACTER SET ascii;
   DECLARE _existing_id BIGINT DEFAULT NULL;
 
   -- Only log if both users exist (skip email-only invites)
@@ -90,6 +92,34 @@ BEGIN
       IF _existing_id IS NOT NULL THEN
         UPDATE yp.contact_activity
            SET timestamp = UNIX_TIMESTAMP(),
+               data = _data
+         WHERE id = _existing_id;
+      ELSE
+        INSERT INTO yp.contact_activity (timestamp, uid, target_uid, event, data)
+        VALUES (UNIX_TIMESTAMP(), _uid, _target_uid, _event, _data);
+      END IF;
+
+    ELSEIF _event = 'task_column_change' THEN
+      -- Column-watch notification: coalesce per (recipient, folder, column) while
+      -- undismissed so a busy column yields ONE refreshing "activity in X" row
+      -- (latest actor/timestamp/data) instead of stacking one row per change.
+      SET _col_key = JSON_UNQUOTE(JSON_EXTRACT(_data, '$.column_key'));
+      SET _col_nid = JSON_UNQUOTE(JSON_EXTRACT(_data, '$.nid'));
+
+      SELECT id INTO _existing_id
+        FROM yp.contact_activity
+       WHERE target_uid = _target_uid
+         AND event = 'task_column_change'
+         AND JSON_UNQUOTE(JSON_EXTRACT(data, '$.column_key')) = _col_key
+         AND IFNULL(JSON_UNQUOTE(JSON_EXTRACT(data, '$.nid')), '') = IFNULL(_col_nid, '')
+         AND dismissed_at IS NULL
+       ORDER BY id DESC
+       LIMIT 1;
+
+      IF _existing_id IS NOT NULL THEN
+        UPDATE yp.contact_activity
+           SET timestamp = UNIX_TIMESTAMP(),
+               uid = _uid,
                data = _data
          WHERE id = _existing_id;
       ELSE

--- a/yellow_page/procedures/contact/contact_task_column_change_unread.sql
+++ b/yellow_page/procedures/contact/contact_task_column_change_unread.sql
@@ -1,0 +1,49 @@
+-- File: schemas/yellow_page/procedures/contact/contact_task_column_change_unread.sql
+-- Purpose: Return the caller's UNDISMISSED task_column_change activity rows so
+-- the activity panel can merge them into the Unread feed. Columns mirror
+-- activity_get_feed_all's contact branch exactly (same shape as
+-- contact_task_assigned_unread), so a merged row renders identically.
+
+DELIMITER $
+
+DROP PROCEDURE IF EXISTS `contact_task_column_change_unread`$
+
+CREATE PROCEDURE `contact_task_column_change_unread`(
+  IN _user_id VARCHAR(16)
+)
+BEGIN
+  SELECT
+    c.id,
+    c.timestamp,
+    c.uid,
+    c.event,
+    'contact' AS event_type,
+    JSON_OBJECT(
+      'uid', c.uid,
+      'email', d1.email,
+      'fullname', d1.fullname
+    ) AS src,
+    JSON_OBJECT(
+      'uid', c.target_uid,
+      'email', d2.email,
+      'fullname', d2.fullname
+    ) AS dest,
+    c.data,
+    0 AS is_read,
+    d1.firstname,
+    d1.lastname,
+    d1.fullname,
+    NULL AS hub_id,
+    NULL AS hub_db_name
+  FROM yp.contact_activity c
+  LEFT JOIN yp.drumate d1 ON c.uid = d1.id
+  LEFT JOIN yp.drumate d2 ON c.target_uid = d2.id
+  WHERE c.target_uid = _user_id
+    AND c.event = 'task_column_change'
+    AND c.dismissed_at IS NULL
+    AND c.uid <> _user_id
+  ORDER BY c.timestamp DESC
+  LIMIT 50;
+END$
+
+DELIMITER ;


### PR DESCRIPTION
…chema

- is_done flag on task_column (alter_task_column_add_is_done) so completion is column-driven, not the literal 'complete' status. task_update_status stamps completed_at from the destination column's is_done; task_column_get returns it.
- task_column_init table + task_column_list seed the four built-in columns as real rows on a scope's first open (initialize-once), so built-ins can be reordered/renamed/recoloured/deleted and those changes persist.
- task_column_reorder proc (persist drag-reorder via FIND_IN_SET).
- task_column_delete re-homes tasks to the first surviving column, not 'todo'.
- Column-watch: task_column_watch table + set/unset/list/watchers procs and contact_task_column_change_unread (+ contact_log_activity) for the bell feed.
- manifest updated with all new tables/patches/procs in dependency order.