### PR TITLE
feat(org): org_provision — atomic TEAM-plan organisation provisioning

### DIFF
--- a/patches/manifest.txt
+++ b/patches/manifest.txt
@@ -122,3 +122,4 @@
   yellow_page/procedures/subscription/payment_clear_entitlement.sql
   yellow_page/procedures/subscription/stripe_event_delete.sql
   yellow_page/procedures/organization/org_provision.sql
+  yellow_page/procedures/directory/get_quota.sql

--- a/patches/manifest.txt
+++ b/patches/manifest.txt
@@ -121,3 +121,4 @@
   drumate/procedures/desk_create_hub.sql
   yellow_page/procedures/subscription/payment_clear_entitlement.sql
   yellow_page/procedures/subscription/stripe_event_delete.sql
+  yellow_page/procedures/organization/org_provision.sql

--- a/yellow_page/procedures/directory/get_quota.sql
+++ b/yellow_page/procedures/directory/get_quota.sql
@@ -109,18 +109,21 @@ BEGIN
     END IF;
   END IF;
 
-  -- CASE 1: Check if user is payer (paid subscription)
-  SELECT quota 
-  FROM quota 
-  WHERE payer_id = _uid 
-  LIMIT 1
-  INTO _quota_json;
-  
-  -- CASE 2: If not payer, check if user belongs to paid organization
-  IF _quota_json IS NULL AND _domain_id > 1 THEN
+  -- CASE 1: tenant-first — the ORGANISATION's row (payer_id =
+  -- organisation.id) outranks a personal payer row when the user lives in
+  -- an org domain (a pro→team upgrader owns both for a while and must get
+  -- the TEAM entitlement, not their stale personal one).
+  IF _domain_id > 1 THEN
+    SELECT q.quota FROM quota q
+      INNER JOIN organisation o ON o.domain_id = q.domain_id AND o.id = q.payer_id
+     WHERE q.domain_id = _domain_id LIMIT 1 INTO _quota_json;
+  END IF;
+
+  -- CASE 2: personal payer row
+  IF _quota_json IS NULL THEN
     SELECT quota 
     FROM quota 
-    WHERE domain_id = _domain_id 
+    WHERE payer_id = _uid 
     LIMIT 1
     INTO _quota_json;
   END IF;

--- a/yellow_page/procedures/directory/get_quota.sql
+++ b/yellow_page/procedures/directory/get_quota.sql
@@ -19,18 +19,21 @@ BEGIN
     SET _is_free_user = TRUE;
     SET _domain_id = 1;
   ELSE
-    -- CASE 1: Check if user is payer
-    SELECT quota 
-    FROM quota 
-    WHERE payer_id = _uid 
-    LIMIT 1
-    INTO _quota_json;
-  
-    -- CASE 2: If not payer, check if user belongs to paid organization
-    IF _quota_json IS NULL AND _domain_id > 1 THEN
+    -- CASE 1: tenant-first — the ORGANISATION's row (payer_id =
+    -- organisation.id) outranks a personal payer row when the user lives
+    -- in an org domain (a pro→team upgrader owns both for a while and must
+    -- get the TEAM entitlement, not their stale personal one).
+    IF _domain_id > 1 THEN
+      SELECT q.quota FROM quota q
+        INNER JOIN organisation o ON o.domain_id = q.domain_id AND o.id = q.payer_id
+       WHERE q.domain_id = _domain_id LIMIT 1 INTO _quota_json;
+    END IF;
+
+    -- CASE 2: personal payer row
+    IF _quota_json IS NULL THEN
       SELECT quota 
       FROM quota 
-      WHERE domain_id = _domain_id 
+      WHERE payer_id = _uid 
       LIMIT 1
       INTO _quota_json;
     END IF;

--- a/yellow_page/procedures/directory/my_disk_limit.sql
+++ b/yellow_page/procedures/directory/my_disk_limit.sql
@@ -21,9 +21,19 @@ BEGIN
 
   -- Entitlement source = yp.quota (canonical), legacy profile.quota fallback (tier 3).
   SELECT domain_id FROM yp.drumate WHERE id = _uid INTO _domain_id;
-  SELECT quota FROM yp.quota WHERE payer_id = _uid LIMIT 1 INTO _quota;
-  IF _quota IS NULL AND _domain_id > 1 THEN
-    SELECT quota FROM yp.quota WHERE domain_id = _domain_id LIMIT 1 INTO _quota;
+  -- Tenant-first entitlement: when the user lives in an org domain, the
+  -- ORGANISATION's quota row (payer_id = organisation.id) outranks any
+  -- personal payer row — a pro→team upgrader owns both for a while and
+  -- must see/enforce the TEAM plan, not their stale personal one. The
+  -- org row is matched via organisation (deterministic: a domain can now
+  -- hold several rows under UNIQUE(domain_id, payer_id)).
+  IF _domain_id > 1 THEN
+    SELECT q.quota FROM yp.quota q
+      INNER JOIN yp.organisation o ON o.domain_id = q.domain_id AND o.id = q.payer_id
+     WHERE q.domain_id = _domain_id LIMIT 1 INTO _quota;
+  END IF;
+  IF _quota IS NULL THEN
+    SELECT quota FROM yp.quota WHERE payer_id = _uid LIMIT 1 INTO _quota;
   END IF;
   IF _quota IS NULL THEN
     SELECT quota FROM yp.drumate WHERE id = _uid INTO _quota;

--- a/yellow_page/procedures/organization/org_provision.sql
+++ b/yellow_page/procedures/organization/org_provision.sql
@@ -127,8 +127,14 @@ proc: BEGIN
   UPDATE yp.vhost SET dom_id = _domain_id
     WHERE id IN (SELECT id FROM yp.hub WHERE owner_id = _payer_id AND id != _org_id);
 
+  -- fqdn rule on a non-main domain is DASH, not dot — the org link is already
+  -- a subdomain, so nesting another level is invalid. Matches both vhost
+  -- factories: drumate_create (user: `<username>-u-<domain>` when domain !=
+  -- main_domain()) and ensure_vhost (hub: CONCAT(hostname, '-', domain) when
+  -- domain_id > 1). First labels are unique on the source domain, so the
+  -- rewritten fqdns cannot collide inside the fresh org domain.
   UPDATE yp.vhost
-    SET fqdn = CONCAT(SUBSTRING_INDEX(fqdn, '.', 1), '.', _link)
+    SET fqdn = CONCAT(SUBSTRING_INDEX(fqdn, '.', 1), '-', _link)
     WHERE dom_id = _domain_id AND id != _org_id;
 
   -- ── Re-key the payer's personal quota row to the new domain ────────────

--- a/yellow_page/procedures/organization/org_provision.sql
+++ b/yellow_page/procedures/organization/org_provision.sql
@@ -1,0 +1,145 @@
+DELIMITER $
+
+-- One-shot, TRANSACTIONAL organisation provisioning for the paid TEAM flow
+-- (docs.drumee.com/technology/yellow-pages-schema). Folds the caller-side
+-- sequence domain_create → domain_grant(dom_owner) → organisation_add into a
+-- single atomic unit so a mid-failure can no longer leave orphaned domain
+-- rows or a domain-less organisation.
+--
+-- Called by the Stripe webhook (checkout.session.completed with
+-- metadata.entity_type='org') BEFORE payment_apply_entitlement, and safe to
+-- re-enter: if the payer already owns an organisation (owner_id is UNIQUE)
+-- the existing row is returned with already=1 and nothing is touched.
+--
+-- Product decisions baked in (2026-07-17):
+--   • move-semantics membership: the payer's single yp.privilege row moves to
+--     the new domain (domain_grant upsert), tier 63 = Remit.dom_owner
+--     (@drumee/server-essentials lex/remit.js — JS is the tier authority).
+--   • the payer's personal hubs MIGRATE into the org domain (hub_to_pro
+--     pattern): hub.domain_id, their entity.dom_id, their vhost.dom_id and
+--     vhost fqdn are rewritten under the organisation link.
+--   • the payer's existing domain-1 quota row is re-keyed to the new domain
+--     (create_organisation prior art) so usage cascades to the org tier.
+--
+-- NB: the legacy 30-day `subscription` insert from organisation_add is
+-- deliberately NOT carried over — Stripe/yp.quota own entitlement now.
+DROP PROCEDURE IF EXISTS `org_provision`$
+CREATE PROCEDURE `org_provision`(
+  IN _payer_id VARCHAR(16) CHARACTER SET ascii,
+  IN _name     VARCHAR(512),
+  IN _ident    VARCHAR(80)
+)
+proc: BEGIN
+  DECLARE _domain_id   INT;
+  DECLARE _domain_name VARCHAR(1000);
+  DECLARE _org_id      VARCHAR(16) CHARACTER SET ascii;
+  DECLARE _link        VARCHAR(1024);
+  DECLARE _taken       INT DEFAULT 0;
+
+  DECLARE EXIT HANDLER FOR SQLEXCEPTION
+  BEGIN
+    ROLLBACK;
+    RESIGNAL;
+  END;
+
+  -- ── Idempotency: one organisation per owner ────────────────────────────
+  SELECT id, domain_id FROM organisation WHERE owner_id = _payer_id LIMIT 1
+    INTO _org_id, _domain_id;
+  IF _org_id IS NOT NULL THEN
+    SELECT o.*, 1 AS already FROM organisation o WHERE o.id = _org_id;
+    LEAVE proc;
+  END IF;
+
+  SET _ident = LOWER(TRIM(_ident));
+  SELECT CONCAT(_ident, '.', main_domain()) INTO _domain_name;
+
+  -- ── Guards (outside the transaction — nothing written yet) ─────────────
+  SELECT COUNT(*) INTO _taken FROM (
+    SELECT id FROM entity       WHERE ident = _ident
+    UNION
+    SELECT id FROM organisation WHERE ident = _ident
+    UNION
+    SELECT id FROM vhost        WHERE fqdn  = _domain_name
+    UNION
+    SELECT CAST(id AS CHAR(16)) FROM domain WHERE name = _domain_name
+  ) t;
+  IF _taken > 0 THEN
+    SELECT 'IDENT_NOT_AVAILABLE' AS error, _ident AS ident;
+    LEAVE proc;
+  END IF;
+
+  START TRANSACTION;
+
+  -- ── Domain (tenant pivot) ───────────────────────────────────────────────
+  INSERT INTO domain (name) VALUES (_domain_name);
+  SELECT id INTO _domain_id FROM domain WHERE name = _domain_name;
+
+  -- ── Owner grant: privilege row + drumate/vhost/entity dom move ─────────
+  -- 63 = Remit.dom_owner. Runs inside THIS transaction.
+  CALL domain_grant(_domain_id, 63, _payer_id, 0);
+
+  -- ── Organisation entity (organisation_add body, minus legacy pieces) ───
+  SELECT id FROM yp.entity
+    WHERE `type` = 'hub' AND area = 'pool'
+      AND JSON_VALUE(settings, "$.pool_state") = "clean"
+    LIMIT 1
+  INTO _org_id;
+  IF _org_id IS NULL THEN
+    ROLLBACK;
+    SELECT 'NO_POOL_ENTITY' AS error;
+    LEAVE proc;
+  END IF;
+
+  SET _link = _domain_name;
+
+  INSERT INTO organisation (`id`, `domain_id`, `name`, `link`, `ident`, `owner_id`, `metadata`)
+  VALUES (
+    _org_id, _domain_id, _name, _link, _ident, _payer_id,
+    JSON_OBJECT(
+      'ident', _ident, 'name', _name, 'link', _link,
+      'domain_id', _domain_id, 'owner_id', _payer_id
+    )
+  );
+
+  UPDATE entity SET
+    `area`     = 'public',
+    `dom_id`   = _domain_id,
+    `type`     = 'organization',
+    `status`   = 'active',
+    `homepage` = ""
+  WHERE id = _org_id;
+
+  INSERT INTO yp.hub (`id`, `owner_id`, `origin_id`, `name`, `serial`, `hubname`, `domain_id`, `profile`)
+  SELECT _org_id, _payer_id, _payer_id, _link, 9999999, NULL, _domain_id, NULL;
+
+  INSERT INTO vhost (`fqdn`, `id`, `dom_id`)
+  VALUES (_domain_name, _org_id, _domain_id);
+
+  -- ── Migrate the payer's personal hubs into the org domain ──────────────
+  -- (drumate_hub_to_pro pattern; the payer's own vhost was already moved by
+  -- domain_grant, its fqdn is rewritten below with the other hub vhosts.)
+  UPDATE yp.hub SET domain_id = _domain_id
+    WHERE owner_id = _payer_id AND id != _org_id;
+
+  UPDATE yp.entity SET dom_id = _domain_id
+    WHERE id IN (SELECT id FROM yp.hub WHERE owner_id = _payer_id AND id != _org_id);
+
+  UPDATE yp.vhost SET dom_id = _domain_id
+    WHERE id IN (SELECT id FROM yp.hub WHERE owner_id = _payer_id AND id != _org_id);
+
+  UPDATE yp.vhost
+    SET fqdn = CONCAT(SUBSTRING_INDEX(fqdn, '.', 1), '.', _link)
+    WHERE dom_id = _domain_id AND id != _org_id;
+
+  -- ── Re-key the payer's personal quota row to the new domain ────────────
+  -- (create_organisation prior art; webhook's payment_apply_entitlement then
+  -- upserts the org-tier quota keyed by this domain.)
+  UPDATE quota SET domain_id = _domain_id
+    WHERE payer_id = _payer_id AND domain_id = 1;
+
+  COMMIT;
+
+  SELECT o.*, 0 AS already FROM organisation o WHERE o.id = _org_id;
+END$
+
+DELIMITER ;

--- a/yellow_page/procedures/utils/disk_limit.sql
+++ b/yellow_page/procedures/utils/disk_limit.sql
@@ -35,9 +35,19 @@ BEGIN
   -- legacy drumate.profile.quota fallback (tier 3) so existing un-migrated users
   -- keep their quota; only paid/explicit yp.quota rows override it.
   SELECT domain_id FROM yp.drumate WHERE id = _owner_id INTO _domain_id;
-  SELECT quota FROM yp.quota WHERE payer_id = _owner_id LIMIT 1 INTO _quota;       -- tier 1: payer
-  IF _quota IS NULL AND _domain_id > 1 THEN
-    SELECT quota FROM yp.quota WHERE domain_id = _domain_id LIMIT 1 INTO _quota;   -- tier 2: org/domain
+  -- Tenant-first entitlement: when the user lives in an org domain, the
+  -- ORGANISATION's quota row (payer_id = organisation.id) outranks any
+  -- personal payer row — a pro→team upgrader owns both for a while and
+  -- must see/enforce the TEAM plan, not their stale personal one. The
+  -- org row is matched via organisation (deterministic: a domain can now
+  -- hold several rows under UNIQUE(domain_id, payer_id)).
+  IF _domain_id > 1 THEN
+    SELECT q.quota FROM yp.quota q
+      INNER JOIN yp.organisation o ON o.domain_id = q.domain_id AND o.id = q.payer_id
+     WHERE q.domain_id = _domain_id LIMIT 1 INTO _quota;
+  END IF;
+  IF _quota IS NULL THEN
+    SELECT quota FROM yp.quota WHERE payer_id = _owner_id LIMIT 1 INTO _quota;
   END IF;
   IF _quota IS NULL THEN
     SELECT quota FROM yp.drumate WHERE id = _owner_id INTO _quota;                 -- tier 3: legacy profile.quota


### PR DESCRIPTION
## Target model (docs.drumee.com/technology/yellow-pages-schema)
TEAM upgrade → the user enters a subdomain BEFORE Stripe checkout → the webhook provisions the organisation after payment; the payer becomes the org owner via `yp.privilege` (dom_owner=63); the payer's personal hubs migrate into the org domain (product decision 2026-07-17).

## New proc `org_provision(payer_id, name, ident)` — one transaction
- Guards before the transaction: ident/organisation/vhost/domain collisions (fqdn `${ident}.${main_domain()}`).
- Inline `domain_create` → `CALL domain_grant(domain_id, 63, payer)` (runs INSIDE the transaction) → organisation + entity(type organization) + org hub (serial 9999999) + vhost — folded from `organisation_add`, but **without** the legacy 30-day subscription insert (Stripe/yp.quota is the entitlement).
- **Migrates the payer's personal hubs** (the `drumate_hub_to_pro` pattern): hub.domain_id + entity.dom_id + vhost.dom_id + fqdn rewrite under the org link.
- Re-keys the payer's domain-1 quota row to the new domain (prior art: create_organisation).
- **Idempotent**: `organisation.owner_id` is UNIQUE — re-entry (webhook retry) returns the existing org with `already=1` and touches nothing.
- `EXIT HANDLER SQLEXCEPTION` → ROLLBACK + RESIGNAL — no more orphaned domain rows.

## Also in this PR
- **Tenant-first quota cascade** (`disk_limit`, `my_disk_limit`, `get_quota` — both the PROCEDURE **and** the FUNCTION that builds the session env): on a domain > 1, the ORG's quota row (matched via `JOIN organisation`) outranks a stale personal payer row, so a pro→team upgrader sees/enforces the TEAM plan.

## Status
Deployed + applied on stage yp. **E2E verified live** (2026-07-17, test account on stage): Team checkout → webhook → org provisioned atomically (domain 1→9, privilege 63, hubs migrated, browser lands on the new org vhost); multiple Stripe events → exactly one org (idempotency proven). Companion PRs: server-team #97 + ui-team #313 (same branch name).

🤖 Generated with [Claude Code](https://claude.com/claude-code)