### PR TITLE
fix(desk): search matches the node name only, not its ancestor path

### DIFF
--- a/drumate/procedures/desk/desk_search.sql
+++ b/drumate/procedures/desk/desk_search.sql
@@ -15,8 +15,7 @@ BEGIN
   DECLARE _idx_time BIGINT UNSIGNED DEFAULT 0;
   DECLARE _ts BIGINT UNSIGNED;
   DECLARE _last_change BIGINT UNSIGNED;
-  DECLARE _use_fulltext BOOLEAN DEFAULT FALSE;
-  
+
   SELECT IFNULL(JSON_VALUE(_args, "$.sort_by"), 'mtime') INTO _sort_by;
   SELECT IFNULL(JSON_VALUE(_args, "$.order"), 'desc') INTO _order;
   SELECT IFNULL(JSON_VALUE(_args, "$.page"), 1) INTO _page;
@@ -159,55 +158,26 @@ BEGIN
 
   CALL yp.pageToLimits(_page, _offset, _range); 
 
-  -- Detect search type
-  IF _pattern != '' 
-     AND _pattern != '.+' 
-     AND _pattern != '.*'
-     AND _pattern REGEXP '[[:space:]]+[^[:space:]]'
-     AND _pattern NOT REGEXP '(\\\^)|(\\\.\\\*)|(\\\.\\\+)' THEN
-    SET _use_fulltext = TRUE;
-  END IF;
-
-  -- Search with improvements
-  IF _use_fulltext THEN
-    -- FULLTEXT search
-    SELECT 
-      m.*,
-      v.fqdn AS vhost,
-      m.pid AS parent_id,
-      MATCH(m.filename, m.filepath) AGAINST(_pattern IN NATURAL LANGUAGE MODE) AS relevance
-    FROM media_index m
-    LEFT JOIN yp.vhost v ON m.hub_id = v.id
-    WHERE m.status = 'active' AND m.filename IS NOT NULL
-      AND MATCH(m.filename, m.filepath) AGAINST(_pattern IN NATURAL LANGUAGE MODE)
-    ORDER BY 
-      relevance DESC,
-      CASE WHEN _sort_by = 'mtime' AND _order = 'desc' THEN m.mtime END DESC,
-      CASE WHEN _sort_by = 'mtime' AND _order = 'asc' THEN m.mtime END ASC,
-      CASE WHEN _sort_by = 'name' AND _order = 'asc' THEN m.filename END ASC,
-      CASE WHEN _sort_by = 'name' AND _order = 'desc' THEN m.filename END DESC
-    LIMIT _offset, _range;
-  ELSE
-    -- REGEXP search
-    SELECT 
-      m.*,
-      v.fqdn AS vhost,
-      m.pid AS parent_id
-    FROM media_index m
-    LEFT JOIN yp.vhost v ON m.hub_id = v.id
-    WHERE m.status = 'active' AND m.filename IS NOT NULL
-      AND (
-        m.filename REGEXP _pattern OR m.filepath REGEXP _pattern
-      )
-    ORDER BY 
-      CASE WHEN _sort_by = 'mtime' AND _order = 'desc' THEN m.mtime END DESC,
-      CASE WHEN _sort_by = 'mtime' AND _order = 'asc' THEN m.mtime END ASC,
-      CASE WHEN _sort_by = 'name' AND _order = 'asc' THEN m.filename END ASC,
-      CASE WHEN _sort_by = 'name' AND _order = 'desc' THEN m.filename END DESC,
-      CASE WHEN _sort_by = 'size' AND _order = 'desc' THEN m.filesize END DESC,
-      CASE WHEN _sort_by = 'size' AND _order = 'asc' THEN m.filesize END ASC
-    LIMIT _offset, _range;
-  END IF;
+  -- Match the typed keyword against the node's OWN name only (m.filename),
+  -- never its ancestor path (m.filepath) — otherwise every node living under a
+  -- folder/workspace whose path contains the keyword would show up as an
+  -- unrelated result. Case-insensitive substring match (utf8mb4_general_ci).
+  SELECT
+    m.*,
+    v.fqdn AS vhost,
+    m.pid AS parent_id
+  FROM media_index m
+  LEFT JOIN yp.vhost v ON m.hub_id = v.id
+  WHERE m.status = 'active' AND m.filename IS NOT NULL
+    AND m.filename LIKE CONCAT('%', _pattern, '%')
+  ORDER BY
+    CASE WHEN _sort_by = 'mtime' AND _order = 'desc' THEN m.mtime END DESC,
+    CASE WHEN _sort_by = 'mtime' AND _order = 'asc' THEN m.mtime END ASC,
+    CASE WHEN _sort_by = 'name' AND _order = 'asc' THEN m.filename END ASC,
+    CASE WHEN _sort_by = 'name' AND _order = 'desc' THEN m.filename END DESC,
+    CASE WHEN _sort_by = 'size' AND _order = 'desc' THEN m.filesize END DESC,
+    CASE WHEN _sort_by = 'size' AND _order = 'asc' THEN m.filesize END ASC
+  LIMIT _offset, _range;
   DROP TEMPORARY TABLE IF EXISTS _user_accessible_hubs;
 END $
 

--- a/patches/changelog.txt
+++ b/patches/changelog.txt
@@ -1,3 +1,6 @@
+2026-07-17 (desk search — match the node name only, not its ancestor path, so results contain the keyword)
+  drumate/procedures/desk/desk_search.sql
+
 2026-07-15 (notification panel — task @-mentions in the chronological feed under Unread ON; fix anonymous share-open dismiss persistence)
   yellow_page/procedures/contact/contact_task_mention_unread.sql
   yellow_page/procedures/secure_share/secure_share_mark_open_seen.sql


### PR DESCRIPTION
## Problem
Desk search returned many unrelated results. Typing a keyword (e.g. `document`) surfaced folders/files whose **own names don't contain the keyword** — they only matched because they live under a folder/workspace whose *path* contains it (e.g. everything inside a "Documents" folder).

## Root cause
`desk_search` matched the keyword against `media_index.filepath` (the full ancestor path) in addition to `filename`:
- single-word → REGEXP branch: `filename REGEXP _pattern OR filepath REGEXP _pattern`
- multi-word → FULLTEXT `MATCH(filename, filepath)` (also OR-s the terms)

`filepath` is the concatenated ancestor path, so any descendant of a path segment containing the keyword matched.

## Fix
Match the keyword against the node's **own name only** (`m.filename`) via a case-insensitive substring (`LIKE CONCAT('%', _pattern, '%')`). Collapsed the two branches into one SELECT and removed the now-unused fulltext toggle. No table change.

- Contract unchanged: same `_args` params and same result columns (the client never used the fulltext-only `relevance` column) → **non-breaking**, applied in place.
- Multi-word is now a contiguous substring match (accepted tradeoff — matches the message-search behavior).

## Verification (stage / drumee.in)
- Real stage data, keyword `sharebox`: old matching = **401** rows (incl. unrelated `package-lock`, `__chat__`, `normalized`); new = **6**, every one with "sharebox" in its own name.
- `CALL desk_search(...)` runs end-to-end; applied to all stage drumate DBs; confirmed on the drumee.in test endpoint.

## Deploy note
`drumate`-class SP → apply to prod drumate DBs + restart the offline factory so newly-provisioned users get the fixed SP (existing users unaffected — it's an SP modification, not a new SP).
