### PR TITLE
feat(contact): storage alerts never reached the Unread notification feed

### DIFF
--- a/patches/changelog.txt
+++ b/patches/changelog.txt
@@ -1,3 +1,6 @@
+2026-07-20 (notification panel — admin-console storage alerts in the chronological feed under Unread ON)
+  yellow_page/procedures/contact/contact_storage_alert_unread.sql
+
 2026-07-17 (desk search — match the node name only, not its ancestor path, so results contain the keyword)
   drumate/procedures/desk/desk_search.sql
 

--- a/patches/manifest.txt
+++ b/patches/manifest.txt
@@ -123,3 +123,4 @@
   yellow_page/procedures/subscription/stripe_event_delete.sql
   yellow_page/procedures/organization/org_provision.sql
   yellow_page/procedures/directory/get_quota.sql
+  yellow_page/procedures/contact/contact_storage_alert_unread.sql

--- a/yellow_page/procedures/contact/contact_storage_alert_unread.sql
+++ b/yellow_page/procedures/contact/contact_storage_alert_unread.sql
@@ -1,0 +1,54 @@
+-- File: schemas/yellow_page/procedures/contact/contact_storage_alert_unread.sql
+-- Purpose: Return the caller's UNDISMISSED storage_alert activity rows so the
+-- activity panel can merge them into the Unread feed. Storage alerts are raised
+-- by the admin console (admin.send_storage_alert -> yp.contact_activity), but
+-- the Unread feed is built from mfs_get_activity_feed, which only reads
+-- yp.mfs_changelog — so without this the alert was stored and visible under
+-- Unread OFF while never appearing in the panel's DEFAULT (Unread ON) view:
+-- the recipient got the email but saw no in-app notification.
+-- Columns mirror activity_get_feed_all's contact branch exactly, so a merged
+-- row is indistinguishable from the same row under Unread OFF.
+
+DELIMITER $
+
+DROP PROCEDURE IF EXISTS `contact_storage_alert_unread`$
+
+CREATE PROCEDURE `contact_storage_alert_unread`(
+  IN _user_id VARCHAR(16)
+)
+BEGIN
+  SELECT
+    c.id,
+    c.timestamp,
+    c.uid,
+    c.event,
+    'contact' AS event_type,
+    JSON_OBJECT(
+      'uid', c.uid,
+      'email', d1.email,
+      'fullname', d1.fullname
+    ) AS src,
+    JSON_OBJECT(
+      'uid', c.target_uid,
+      'email', d2.email,
+      'fullname', d2.fullname
+    ) AS dest,
+    c.data,
+    0 AS is_read,
+    d1.firstname,
+    d1.lastname,
+    d1.fullname,
+    NULL AS hub_id,
+    NULL AS hub_db_name
+  FROM yp.contact_activity c
+  LEFT JOIN yp.drumate d1 ON c.uid = d1.id
+  LEFT JOIN yp.drumate d2 ON c.target_uid = d2.id
+  WHERE c.target_uid = _user_id
+    AND c.event = 'storage_alert'
+    AND c.dismissed_at IS NULL
+    AND c.uid <> _user_id
+  ORDER BY c.timestamp DESC
+  LIMIT 50;
+END$
+
+DELIMITER ;


### PR DESCRIPTION
## Problem

Admin console → Storage → *Send storage alert*: the recipient **got the email but no in-app notification**.

## Root cause

The activity panel opens on **Unread ON**, and that feed is built by `mfs_get_activity_feed`, which reads `yp.mfs_changelog` **only**. Storage alerts are written to `yp.contact_activity`, so they appeared under *All activity* but never in the default view.

This is a known shape: task assignments and @-mentions solve it with per-event `*_unread` procs that `activity.get_feed` merges when `unread_only=1`. `storage_alert` was added to `contact_activity` without its matching proc.

## Change

New `contact_storage_alert_unread` mirroring `contact_task_assigned_unread` exactly (same columns, so a merged row is indistinguishable from the Unread-OFF row). Registered in `patches/manifest.txt`.

Paired with server-team PR adding it to the merge list in `activity.get_feed`.

## Verification (live, drumee.in)

Sent an alert from `test.owner1@drumee.com` → `vu@drumee.org`:

| | Before | After |
|---|---|---|
| `get_feed(unread_only=1)` | 10 rows, **no** storage_alert | 12 rows, **storage_alert present** |
| `get_feed(unread_only=0)` | had it | unchanged (no double-show) |
| Panel default view | nothing | "Test Owner1 sent you a storage alert…" |

## Known gap, not fixed here

`activity.get_unread_count` still returns 0 — `mfs_get_unread_count` also reads only `mfs_changelog`, so **no** contact event (including the existing task_assigned) feeds the bell badge. Pre-existing and wider than this ticket; worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)