### PR TITLE
fix(desk): order search results by closest name match first

### DIFF
--- a/drumate/procedures/desk/desk_search.sql
+++ b/drumate/procedures/desk/desk_search.sql
@@ -16,7 +16,10 @@ BEGIN
   DECLARE _ts BIGINT UNSIGNED;
   DECLARE _last_change BIGINT UNSIGNED;
 
-  SELECT IFNULL(JSON_VALUE(_args, "$.sort_by"), 'mtime') INTO _sort_by;
+  -- Default to relevance: this proc only serves the desk search bar, where the
+  -- closest name match is what the user is looking for. An explicit sort_by
+  -- ('mtime' | 'name' | 'size') still behaves exactly as before.
+  SELECT IFNULL(JSON_VALUE(_args, "$.sort_by"), 'relevance') INTO _sort_by;
   SELECT IFNULL(JSON_VALUE(_args, "$.order"), 'desc') INTO _order;
   SELECT IFNULL(JSON_VALUE(_args, "$.page"), 1) INTO _page;
   SELECT IFNULL(JSON_VALUE(_args, "$.pagelength"), 45) INTO @rows_per_page;
@@ -171,6 +174,24 @@ BEGIN
   WHERE m.status = 'active' AND m.filename IS NOT NULL
     AND m.filename LIKE CONCAT('%', _pattern, '%')
   ORDER BY
+    -- Relevance (the default): closest name match first.
+    --   0 the name IS the keyword, 1 the name starts with it, 2 the keyword
+    --   starts a word inside the name (separators _ - . are read as spaces),
+    --   3 it appears anywhere else.
+    -- Ties break on the shorter (so more specific) name, then most recent.
+    -- Every term is inert unless sort_by = 'relevance', so the explicit
+    -- mtime/name/size orders below keep their existing behaviour.
+    CASE WHEN _sort_by = 'relevance' THEN
+      CASE
+        WHEN m.filename = _pattern THEN 0
+        WHEN m.filename LIKE CONCAT(_pattern, '%') THEN 1
+        WHEN REPLACE(REPLACE(REPLACE(m.filename, '_', ' '), '-', ' '), '.', ' ')
+             LIKE CONCAT('% ', _pattern, '%') THEN 2
+        ELSE 3
+      END
+    END ASC,
+    CASE WHEN _sort_by = 'relevance' THEN CHAR_LENGTH(m.filename) END ASC,
+    CASE WHEN _sort_by = 'relevance' THEN m.mtime END DESC,
     CASE WHEN _sort_by = 'mtime' AND _order = 'desc' THEN m.mtime END DESC,
     CASE WHEN _sort_by = 'mtime' AND _order = 'asc' THEN m.mtime END ASC,
     CASE WHEN _sort_by = 'name' AND _order = 'asc' THEN m.filename END ASC,

--- a/patches/changelog.txt
+++ b/patches/changelog.txt
@@ -1,3 +1,6 @@
+2026-07-20 (desk search — order results by closest name match first, instead of last-modified)
+  drumate/procedures/desk/desk_search.sql
+
 2026-07-20 (notification panel — admin-console storage alerts in the chronological feed under Unread ON)
   yellow_page/procedures/contact/contact_storage_alert_unread.sql
 


### PR DESCRIPTION
## Problem
Desk search returned correct name matches but ordered them by **last modified**, so the best matches for a keyword were scattered among whatever happened to be recent. Requested: show the closest name match first.

## Fix
`desk_search` now orders by **relevance** (the default for this proc):

| Rank | Meaning | Example (searching `test`) |
|---|---|---|
| 0 | the name **is** the keyword | `test`, `TEST` |
| 1 | the name **starts with** it | `test_file`, `testing abc` |
| 2 | the keyword **starts a word** inside the name (`_ - .` read as separators) | `my_test_file`, `my-test-file`, `my.test.file`, `my test file` |
| 3 | it appears anywhere else | `latest`, `contest`, `greatest hits` |

Ties break on the shorter (more specific) name, then most recent.

## Why this is safe
- `desk_search` is a **leaf proc with exactly one caller** — `desk.js` `search()`, which passes only `{pattern, page}` and no `sort_by` (verified: no `CALL desk_search` anywhere in schemas; `desk_recent_files` / `desk_search_by_index` only mention it in comments). Making relevance the default therefore needs **no server change**, so there is no DB-vs-code deploy-ordering hazard.
- Every relevance term is wrapped in `CASE WHEN _sort_by = 'relevance'`, so it is **inert** for any explicit sort. Regression-tested on stage: `sort_by='mtime'` still returns strictly descending mtime, `sort_by='name'` still alphabetical.
- The **name-only matching rule is unchanged** — only ordering changed; the WHERE clause is untouched.
- Implemented with `REPLACE`/`LIKE` and deliberately **no `REGEXP`**, so the regex-injection surface removed by the earlier fix is not reintroduced.

## Verification (stage)
Synthetic proof of all four tiers (`test`/`TEST`→0; `test_file`,`testing abc`→1; `my_test_file`/`my test file`/`my-test-file`/`my.test.file`→2; `latest`,`contest`,`greatest hits`→3) plus real data (`package` → exact `package` then `package-lock`; `box` → `box-tags` then `checkbox` then `editbox_*`). Applied to all stage drumate DBs and confirmed on drumee.in.

## Deploy note
`drumate`-class SP: re-apply `desk_search.sql` to the prod drumate DBs + restart the offline factory. No server deploy and no table change.
