### PR TITLE
feat(subscription): payment_get_org returns the org vhost link/ident

### DIFF
--- a/patches/changelog.txt
+++ b/patches/changelog.txt
@@ -1,3 +1,6 @@
+2026-07-21 (billing email deep-link — payment_get_org returns the org vhost link/ident)
+  yellow_page/procedures/subscription/payment_get_org.sql
+
 2026-07-20 (desk search — order results by closest name match first, instead of last-modified)
   drumate/procedures/desk/desk_search.sql
 

--- a/yellow_page/procedures/subscription/payment_get_org.sql
+++ b/yellow_page/procedures/subscription/payment_get_org.sql
@@ -6,7 +6,9 @@ CREATE PROCEDURE `payment_get_org`(
 BEGIN
   -- The org this user is the billing owner of (organisation.owner_id), plus the
   -- org's existing Stripe customer (subscription_new keyed on the organisation id).
-  SELECT o.id, o.domain_id, o.name, o.owner_id, s.customer_id
+  -- link/ident: the org's vhost — emails must deep-link the RECIPIENT's host
+  -- (the session cookie is host-scoped; a main-domain link lands signed-out).
+  SELECT o.id, o.domain_id, o.name, o.owner_id, o.link, o.ident, s.customer_id
   FROM yp.organisation o
   LEFT JOIN yp.subscription_new s ON s.entity_id = o.id
   WHERE o.owner_id = _uid


### PR DESCRIPTION
Companion to the billing-email logout fix (server-team): the "Open Drumee" link must target the **recipient's host** — the session cookie is host-scoped, so an org member's session lives on their org vhost and a main-domain link lands signed-out. Adds `o.link, o.ident` to the proc's SELECT (backward-compatible extra columns).

Applied to yp on drumee.in and smoke-tested: returns `alertdemoteam.drumee.in` for the test org.

🤖 Generated with [Claude Code](https://claude.com/claude-code)