### PR TITLE
fix(task): scope task_column by folder so every board keeps its built-in columns

### DIFF
--- a/common/patches/alter_task_column_scope_pk.sql
+++ b/common/patches/alter_task_column_scope_pk.sql
@@ -1,0 +1,106 @@
+-- ALTER TABLE migration — existing hub / drumate databases
+-- Make task_column's identity FOLDER-SCOPED: PRIMARY KEY (id, nid).
+--
+-- Why: task_column_list seeds the four built-in columns as real rows per folder
+-- scope, using their canonical status keys as ids ('todo', 'in_progress',
+-- 'to_review', 'complete'). Under PRIMARY KEY (id) those ids can exist only
+-- ONCE PER DATABASE, so only the first scope whose board is opened gets them —
+-- every other scope's INSERT IGNORE hits the key collision, stores nothing, yet
+-- still records its task_column_init marker and is therefore never seeded
+-- again. Boards in those scopes render their custom columns alone and silently
+-- hide every task whose status is a built-in key.
+--
+-- nid must become NOT NULL first: a PRIMARY KEY column cannot hold NULL, and
+-- the workspace-root scope has historically been stored as NULL. '' is already
+-- the canonical root marker elsewhere (task_column_init.scope_key uses
+-- IFNULL(_nid, '')), so root collapses to '' here too. The task_column procs
+-- normalise _nid to '' so `nid <=> _nid` keeps matching root-scope calls.
+--
+-- (id, nid) is a superset of the existing unique (id), so the new key can never
+-- collide on existing rows. Every step is guarded and safe to run repeatedly.
+--
+-- ⚠️ Ships in LOCKSTEP with the task_column procs (task_column_get/update/
+-- delete gain an _nid parameter) and their server + UI call sites. Applying
+-- this migration alone leaves delete/update keyed on id only, which under a
+-- composite key would hit EVERY scope's copy of a built-in.
+--
+-- Apply to every common-class DB individually, e.g.:
+--   bin/patch-from-file common/patches/alter_task_column_scope_pk.sql common
+
+SET @has_tc := (
+  SELECT COUNT(*) FROM information_schema.TABLES
+   WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'task_column'
+);
+
+-- ---------------------------------------------------------------------------
+-- 1. Collapse the historical NULL root scope onto ''
+-- ---------------------------------------------------------------------------
+SET @sql := IF(
+  @has_tc = 1,
+  'UPDATE `task_column` SET `nid` = '''' WHERE `nid` IS NULL',
+  'DO 0'
+);
+PREPARE st FROM @sql; EXECUTE st; DEALLOCATE PREPARE st;
+
+-- ---------------------------------------------------------------------------
+-- 2. nid NOT NULL (no-op when already applied)
+-- ---------------------------------------------------------------------------
+SET @nullable := (
+  SELECT COUNT(*) FROM information_schema.COLUMNS
+   WHERE TABLE_SCHEMA = DATABASE()
+     AND TABLE_NAME   = 'task_column'
+     AND COLUMN_NAME  = 'nid'
+     AND IS_NULLABLE  = 'YES'
+);
+SET @sql := IF(
+  @has_tc = 1 AND @nullable = 1,
+  'ALTER TABLE `task_column` MODIFY `nid` VARCHAR(16) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL DEFAULT ''''',
+  'DO 0'
+);
+PREPARE st FROM @sql; EXECUTE st; DEALLOCATE PREPARE st;
+
+-- ---------------------------------------------------------------------------
+-- 3. PRIMARY KEY (id) -> (id, nid)
+--    Guarded on the current key column count, so a re-run is a no-op.
+-- ---------------------------------------------------------------------------
+SET @pk_cols := (
+  SELECT COUNT(*) FROM information_schema.STATISTICS
+   WHERE TABLE_SCHEMA = DATABASE()
+     AND TABLE_NAME   = 'task_column'
+     AND INDEX_NAME   = 'PRIMARY'
+);
+SET @sql := IF(
+  @has_tc = 1 AND @pk_cols = 1,
+  'ALTER TABLE `task_column` DROP PRIMARY KEY, ADD PRIMARY KEY (`id`, `nid`)',
+  'DO 0'
+);
+PREPARE st FROM @sql; EXECUTE st; DEALLOCATE PREPARE st;
+
+-- ---------------------------------------------------------------------------
+-- 4. Purge the poisoned init markers.
+--    A scope marked "seeded" that holds NO built-in row was a swallowed
+--    INSERT IGNORE; clearing the marker lets task_column_list seed it properly
+--    on the next open, now that the composite key permits it.
+--
+--    ⚠️ KNOWN AMBIGUITY: a scope where the user genuinely DELETED all four
+--    built-ins is indistinguishable from a poisoned one — no timestamp or flag
+--    separates them — so such a board would be re-seeded on next open. That is
+--    the same state a fresh board starts in, and is strictly preferable to
+--    permanently hidden tasks. Scopes retaining even ONE built-in are left
+--    untouched, so ordinary single-column deletes still persist.
+-- ---------------------------------------------------------------------------
+SET @has_init := (
+  SELECT COUNT(*) FROM information_schema.TABLES
+   WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'task_column_init'
+);
+SET @sql := IF(
+  @has_tc = 1 AND @has_init = 1,
+  'DELETE i FROM `task_column_init` i
+    WHERE NOT EXISTS (
+      SELECT 1 FROM `task_column` c
+       WHERE c.`nid` = i.`scope_key`
+         AND c.`id` IN (''todo'', ''in_progress'', ''to_review'', ''complete'')
+    )',
+  'DO 0'
+);
+PREPARE st FROM @sql; EXECUTE st; DEALLOCATE PREPARE st;

--- a/common/procedures/task/task_column_create.sql
+++ b/common/procedures/task/task_column_create.sql
@@ -9,17 +9,24 @@ CREATE PROCEDURE `task_column_create`(
 BEGIN
   DECLARE _pos INT DEFAULT 0;
   DECLARE _now INT DEFAULT UNIX_TIMESTAMP();
+  -- '' is the canonical root scope: task_column.nid is part of the primary key
+  -- and cannot be NULL. Comparing IFNULL(nid,'') = _sk keeps this correct
+  -- whether nid still stores NULL for root (pre alter_task_column_scope_pk) or
+  -- '' (post), so the proc is safe to apply before OR after that migration.
+  DECLARE _sk VARCHAR(16) DEFAULT IFNULL(_nid, '');
 
-  -- Append to the right end of this folder's custom columns.
+  -- Append to the right end of this folder's columns.
   SELECT IFNULL(MAX(position), 0) + 1 INTO _pos
     FROM task_column
-   WHERE nid <=> _nid;
+   WHERE IFNULL(nid, '') = _sk;
 
   INSERT INTO task_column (id, nid, name, theme, position, ctime, mtime)
-  VALUES (_id, _nid, _name, IFNULL(_theme, 'default'), _pos, _now, _now);
+  VALUES (_id, _sk, _name, IFNULL(_theme, 'default'), _pos, _now, _now);
 
-  SELECT id, nid, name, theme, position, ctime, mtime
+  -- Scoped: a built-in id exists once per scope, so id alone is ambiguous.
+  SELECT id, nid, name, theme, position, is_done, ctime, mtime
     FROM task_column
-   WHERE id = _id;
+   WHERE id = _id
+     AND IFNULL(nid, '') = _sk;
 END$
 DELIMITER ;

--- a/common/procedures/task/task_column_delete_v2.sql
+++ b/common/procedures/task/task_column_delete_v2.sql
@@ -1,0 +1,50 @@
+DELIMITER $
+DROP PROCEDURE IF EXISTS `task_column_delete_v2`$
+CREATE PROCEDURE `task_column_delete_v2`(
+  IN _id VARCHAR(16),
+  IN _nid VARCHAR(16)
+)
+BEGIN
+  -- CHARACTER SET ascii to match task_column.nid / task.nid: without it the
+  -- variable takes the database default (utf8mb4) and every comparison against
+  -- the ascii column raises ER_CANT_AGGREGATE_2COLLATIONS (1267).
+  DECLARE _moved INT DEFAULT 0;
+  DECLARE _fallback VARCHAR(16) CHARACTER SET ascii DEFAULT NULL;
+  DECLARE _scope VARCHAR(16) CHARACTER SET ascii DEFAULT IFNULL(_nid, '');
+  DECLARE _tnid VARCHAR(16) CHARACTER SET ascii DEFAULT NULLIF(IFNULL(_nid, ''), '');
+
+  -- v2 takes the folder scope instead of deriving it from the id. Built-in ids
+  -- ('todo', 'complete', ...) are literal status keys that now exist once PER
+  -- SCOPE, so the old `WHERE id = _id` would delete that built-in from EVERY
+  -- board in the workspace and re-home the wrong tasks.
+  --
+  -- Two spellings of "root" have to be reconciled: task_column.nid uses ''
+  -- (it is part of the primary key and cannot be NULL) while task.nid keeps
+  -- NULL. _scope addresses task_column, _tnid addresses task.
+
+  -- Re-home this column's tasks onto the first surviving column of the SAME
+  -- scope (board order), so deleting any column — built-in or custom — never
+  -- orphans a task.
+  SELECT id INTO _fallback
+    FROM task_column
+   WHERE id <> _id
+     AND IFNULL(nid, '') = _scope
+   ORDER BY position, ctime
+   LIMIT 1;
+
+  IF _fallback IS NOT NULL THEN
+    UPDATE task
+       SET status = _fallback,
+           mtime  = UNIX_TIMESTAMP()
+     WHERE status = _id
+       AND nid <=> _tnid;
+    SET _moved = ROW_COUNT();
+  END IF;
+
+  DELETE FROM task_column
+   WHERE id = _id
+     AND IFNULL(nid, '') = _scope;
+
+  SELECT ROW_COUNT() AS affected, _id AS id, _moved AS moved_tasks, _fallback AS moved_to;
+END$
+DELIMITER ;

--- a/common/procedures/task/task_column_get_v2.sql
+++ b/common/procedures/task/task_column_get_v2.sql
@@ -1,0 +1,30 @@
+DELIMITER $
+DROP PROCEDURE IF EXISTS `task_column_get_v2`$
+CREATE PROCEDURE `task_column_get_v2`(
+  IN _id VARCHAR(16),
+  IN _nid VARCHAR(16)
+)
+BEGIN
+  -- CHARACTER SET ascii to match task_column.nid: without it the variable takes
+  -- the database default (utf8mb4) and comparing it against the ascii column
+  -- raises ER_CANT_AGGREGATE_2COLLATIONS (1267).
+  DECLARE _scope VARCHAR(16) CHARACTER SET ascii DEFAULT IFNULL(_nid, '');
+
+  -- Existence/lookup check used by the task service to validate a status key
+  -- and to read its is_done flag (completion is column-driven).
+  --
+  -- v2 takes the folder scope: built-in ids ('todo', 'complete', ...) are
+  -- literal status keys that now exist once PER SCOPE, so id alone is
+  -- ambiguous and would return one row per board.
+  --
+  -- IFNULL on BOTH sides so this behaves identically whether task_column.nid
+  -- still stores NULL for the root scope (pre alter_task_column_scope_pk) or
+  -- '' (post) — the proc is therefore safe to apply before OR after that
+  -- migration. task_column holds a handful of rows per DB, so losing idx_nid
+  -- here is immaterial.
+  SELECT id, nid, name, theme, position, is_done, ctime, mtime
+    FROM task_column
+   WHERE id = _id
+     AND IFNULL(nid, '') = _scope;
+END$
+DELIMITER ;

--- a/common/procedures/task/task_column_list.sql
+++ b/common/procedures/task/task_column_list.sql
@@ -15,21 +15,27 @@ BEGIN
   -- (a deleted built-in must NOT come back on the next open). Their ids ARE the
   -- canonical status keys, so pre-existing tasks still match; 'complete' is
   -- flagged is_done = 1 so completion tracking follows the column, not a label.
+  -- _sk is the canonical scope spelling: '' for the workspace root, matching
+  -- task_column_init.scope_key and task_column.nid (which is part of the
+  -- primary key and so cannot be NULL). Comparing IFNULL(nid,'') = _sk keeps
+  -- this correct whether nid still stores NULL for root (pre
+  -- alter_task_column_scope_pk) or '' (post), so the proc is safe to apply
+  -- before OR after that migration.
   SELECT COUNT(*) INTO _init FROM task_column_init WHERE scope_key = _sk;
   IF _init = 0 THEN
     -- Make room so the built-ins lead any columns a folder already had.
-    UPDATE task_column SET position = position + 4 WHERE nid <=> _nid;
+    UPDATE task_column SET position = position + 4 WHERE IFNULL(nid, '') = _sk;
     INSERT IGNORE INTO task_column (id, nid, name, theme, position, is_done, ctime, mtime) VALUES
-      ('todo',        _nid, 'To do',       'default', 0, 0, _now, _now),
-      ('in_progress', _nid, 'In progress', 'purple',  1, 0, _now, _now),
-      ('to_review',   _nid, 'To review',   'orange',  2, 0, _now, _now),
-      ('complete',    _nid, 'Complete',    'green',   3, 1, _now, _now);
+      ('todo',        _sk, 'To do',       'default', 0, 0, _now, _now),
+      ('in_progress', _sk, 'In progress', 'purple',  1, 0, _now, _now),
+      ('to_review',   _sk, 'To review',   'orange',  2, 0, _now, _now),
+      ('complete',    _sk, 'Complete',    'green',   3, 1, _now, _now);
     INSERT INTO task_column_init (scope_key, ctime) VALUES (_sk, _now);
   END IF;
 
   SELECT id, nid, name, theme, position, is_done, ctime, mtime
     FROM task_column
-   WHERE nid <=> _nid
+   WHERE IFNULL(nid, '') = _sk
    ORDER BY position, ctime;
 END$
 DELIMITER ;

--- a/common/procedures/task/task_column_reorder.sql
+++ b/common/procedures/task/task_column_reorder.sql
@@ -5,19 +5,26 @@ CREATE PROCEDURE `task_column_reorder`(
   IN _order TEXT
 )
 BEGIN
-  -- Persist a drag-reorder of custom columns. _order is the comma-separated
+  -- '' is the canonical root scope: task_column.nid is part of the primary key
+  -- and cannot be NULL. Comparing IFNULL(nid,'') = _sk keeps this correct
+  -- whether nid still stores NULL for root (pre alter_task_column_scope_pk) or
+  -- '' (post), so the proc is safe to apply before OR after that migration.
+  DECLARE _sk VARCHAR(16) DEFAULT IFNULL(_nid, '');
+
+  -- Persist a drag-reorder of the board's columns. _order is the comma-separated
   -- column ids in their new left-to-right order; each column's position is set
   -- to its index in that list (FIND_IN_SET is 1-based). Scoped to the folder so
-  -- one folder's reorder can't touch another's rows.
+  -- one folder's reorder can't touch another's rows — which matters more now
+  -- that built-in ids are shared across scopes.
   UPDATE task_column
      SET position = FIND_IN_SET(id, _order),
          mtime = UNIX_TIMESTAMP()
-   WHERE nid <=> _nid
+   WHERE IFNULL(nid, '') = _sk
      AND FIND_IN_SET(id, _order) > 0;
 
-  SELECT id, nid, name, theme, position, ctime, mtime
+  SELECT id, nid, name, theme, position, is_done, ctime, mtime
     FROM task_column
-   WHERE nid <=> _nid
+   WHERE IFNULL(nid, '') = _sk
    ORDER BY position, ctime;
 END$
 DELIMITER ;

--- a/common/procedures/task/task_column_update_v2.sql
+++ b/common/procedures/task/task_column_update_v2.sql
@@ -1,0 +1,36 @@
+DELIMITER $
+DROP PROCEDURE IF EXISTS `task_column_update_v2`$
+CREATE PROCEDURE `task_column_update_v2`(
+  IN _id VARCHAR(16),
+  IN _nid VARCHAR(16),
+  IN _name VARCHAR(100),
+  IN _theme VARCHAR(20)
+)
+BEGIN
+  -- CHARACTER SET ascii to match task_column.nid: without it the variable takes
+  -- the database default (utf8mb4) and comparing it against the ascii column
+  -- raises ER_CANT_AGGREGATE_2COLLATIONS (1267).
+  DECLARE _scope VARCHAR(16) CHARACTER SET ascii DEFAULT IFNULL(_nid, '');
+
+  -- NULL keeps the existing value (rename and recolor are independent).
+  --
+  -- v2 takes the folder scope. Built-in ids ('todo', 'complete', ...) are
+  -- literal status keys that now exist once PER SCOPE, so keying on id alone
+  -- would rename/recolour that built-in on EVERY board in the workspace.
+  --
+  -- IFNULL on both sides so this is correct whether task_column.nid still
+  -- stores NULL for the root scope (pre alter_task_column_scope_pk) or ''
+  -- (post) — safe to apply before OR after that migration.
+  UPDATE task_column
+     SET name  = IFNULL(_name, name),
+         theme = IFNULL(_theme, theme),
+         mtime = UNIX_TIMESTAMP()
+   WHERE id = _id
+     AND IFNULL(nid, '') = _scope;
+
+  SELECT id, nid, name, theme, position, is_done, ctime, mtime
+    FROM task_column
+   WHERE id = _id
+     AND IFNULL(nid, '') = _scope;
+END$
+DELIMITER ;

--- a/common/procedures/task/task_update_status.sql
+++ b/common/procedures/task/task_update_status.sql
@@ -6,18 +6,29 @@ CREATE PROCEDURE `task_update_status`(
 )
 BEGIN
   DECLARE _rank INT DEFAULT 0;
-  DECLARE _nid VARCHAR(16) DEFAULT NULL;
+  -- CHARACTER SET ascii to match task.nid / task_column.nid: without it the
+  -- variable takes the database default (utf8mb4) and comparing it against the
+  -- ascii column raises ER_CANT_AGGREGATE_2COLLATIONS (1267).
+  DECLARE _nid VARCHAR(16) CHARACTER SET ascii DEFAULT NULL;
   DECLARE _done TINYINT DEFAULT 0;
 
   -- Resolve the task's folder so the destination-column rank is computed
   -- within the same folder, not across the whole hub.
   SELECT nid INTO _nid FROM task WHERE id = _id;
 
-  -- Is the destination a "done" column? Completion is now driven by the
-  -- column's is_done flag, not the literal 'complete' key — so a renamed or
+  -- Is the destination a "done" column? Completion is driven by the column's
+  -- is_done flag, not the literal 'complete' key — so a renamed or
   -- user-created done column still stamps completed_at correctly.
+  --
+  -- Scoped to the task's own folder: built-in ids are literal status keys that
+  -- exist once PER SCOPE, so an unscoped lookup reads another board's flag.
+  -- task_column.nid uses '' for root (primary-key column, cannot be NULL)
+  -- while task.nid keeps NULL, hence IFNULL on both sides — which also keeps
+  -- this correct before AND after alter_task_column_scope_pk.
   SELECT COALESCE(MAX(is_done), 0) INTO _done
-    FROM task_column WHERE id = _status;
+    FROM task_column
+   WHERE id = _status
+     AND IFNULL(nid, '') = IFNULL(_nid, '');
 
   -- Place task at the bottom of the destination (folder, status) column.
   SELECT IFNULL(MAX(rank), 0) + 1

--- a/common/tables/task_column.sql
+++ b/common/tables/task_column.sql
@@ -1,18 +1,29 @@
--- Custom Kanban columns, folder-scoped like tasks (nid = media node id of the
--- folder; NULL = workspace root). The four built-in columns (todo, in_progress,
--- to_review, complete) are implicit client-side and are NOT stored here — only
--- user-created columns are. A custom column's id doubles as the task.status
--- value for tasks placed in it.
+-- Kanban columns, folder-scoped like tasks (nid = media node id of the folder;
+-- '' = workspace root). Holds BOTH the four built-in columns (todo,
+-- in_progress, to_review, complete — seeded per scope on a board's first open
+-- by task_column_list) and user-created ones, so built-ins can be renamed,
+-- recoloured, reordered and deleted like any other column. A column's id
+-- doubles as the task.status value for tasks placed in it.
+--
+-- The key is (id, nid): built-in ids ARE literal status keys, so the same id
+-- must be able to exist once PER SCOPE. Keying on id alone let only the first
+-- scope opened hold them — every later scope's INSERT IGNORE silently hit the
+-- collision and stored nothing (see patches/alter_task_column_scope_pk.sql).
+--
+-- nid is NOT NULL because a PRIMARY KEY column cannot hold NULL; the root
+-- scope is '' here, matching task_column_init.scope_key. NOTE task.nid keeps
+-- NULL for root, so the procs map between the two with IFNULL/NULLIF.
 CREATE TABLE IF NOT EXISTS task_column (
   id varchar(16) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL,
-  nid varchar(16) CHARACTER SET ascii COLLATE ascii_general_ci DEFAULT NULL,
+  nid varchar(16) CHARACTER SET ascii COLLATE ascii_general_ci NOT NULL DEFAULT '',
   name varchar(100) NOT NULL,
   -- Visual theme key from the 10-swatch palette (Figma 2040-106090):
   -- default | orange | yellow | green | cyan | blue | purple | pink | red
   theme varchar(20) NOT NULL DEFAULT 'default',
   position int(11) NOT NULL DEFAULT 0,
+  is_done tinyint(1) NOT NULL DEFAULT 0,
   ctime int(11) NOT NULL DEFAULT 0,
   mtime int(11) NOT NULL DEFAULT 0,
-  PRIMARY KEY (id),
+  PRIMARY KEY (id, nid),
   KEY idx_nid (nid)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;

--- a/patches/changelog.txt
+++ b/patches/changelog.txt
@@ -1,3 +1,18 @@
+2026-07-22 (task board — built-in columns only ever landed on the first board
+  opened: task_column keyed on (id) alone while the built-ins are seeded per
+  folder scope. Key becomes (id, nid), nid NOT NULL with '' for root; get /
+  update / delete gain _v2 forms taking the scope. Apply _v2 procs -> server+ui
+  -> the ALTER.)
+  common/patches/alter_task_column_scope_pk.sql
+  common/tables/task_column.sql
+  common/procedures/task/task_column_get_v2.sql
+  common/procedures/task/task_column_update_v2.sql
+  common/procedures/task/task_column_delete_v2.sql
+  common/procedures/task/task_column_list.sql
+  common/procedures/task/task_column_create.sql
+  common/procedures/task/task_column_reorder.sql
+  common/procedures/task/task_update_status.sql
+
 2026-07-21 (billing email deep-link — payment_get_org returns the org vhost link/ident)
   yellow_page/procedures/subscription/payment_get_org.sql
 


### PR DESCRIPTION
Fixes the task-board bug found on production today: **built-in columns only ever landed on the first board opened in a workspace.**

## Root cause

`task_column` is keyed on `(id)` alone (from `alter_task_custom_columns.sql`, whose comment still reads *"Built-in columns stay implicit client-side"*). But `task_column_list` now seeds the four built-ins **per folder scope**, using their literal status keys as ids. Those ids can therefore exist only **once per database**, not once per scope.

Result: the first scope whose board is opened takes them. Every later scope's `INSERT IGNORE` silently swallows the key collision, stores nothing — yet still writes its `task_column_init` marker, so it is **never seeded again**. Those boards render their custom columns alone and hide every task sitting in a built-in status.

Reproduced on stage (`3_ce2f1d2cce2f1d2d`, 2 scopes, 1 seeded):

```
CALL task_column_list('5502e9bd5502e9c4')  ->  0 rows        (expected 4 built-ins)
task_column_init                           ->  marker WRITTEN
built-in rows for that scope               ->  0
```

On production this hid **79 of 137 tasks** on one board.

Why testing missed it: every stage workspace has exactly one seeded scope (1 scope with columns, 1 marker). Two of those DBs have a second task scope whose board was simply never opened. It needs 2+ scopes in one database to reproduce.

## The fix

- **`PRIMARY KEY (id, nid)`** — built-in ids are per-scope by design, so the key must be too.
- **`nid NOT NULL DEFAULT ''`** — a primary-key column cannot hold NULL, and the root scope was NULL. `''` is already the root convention (`task_column_init.scope_key` uses `IFNULL(_nid,'')`). Note `task.nid` keeps NULL, so the procs map between the two spellings.
- **`task_column_get/update/delete` gain `_v2` forms taking the scope.** Under a composite key, `WHERE id = _id` would rename or delete a built-in on **every** board in the workspace — this is the part that must not ship alone.
- **Marker purge** in the migration, for scopes holding no built-in row.

## Apply order — no step can break the one before it

1. **`_v2` procs** — purely additive, nothing calls them yet.
2. **server + ui** switch to `_v2` (⚠️ **not in this PR** — see below).
3. **`alter_task_column_scope_pk.sql`** — by now nothing calls the old procs.

The scope procs compare `IFNULL(nid,'') = _scope`, so they behave identically whether `nid` still stores `NULL` or `''`. That is what removes the ordering hazard — deliberately, after a DB/code ordering mismatch caused an incident earlier today.

## Validation

Run against a **throwaway copy of a real database** (dropped afterwards), with the scratch DB created at `utf8mb4_general_ci` to match production:

| Check | Result |
|---|---|
| Procs apply on the OLD schema, pre-migration | ✅ |
| Migration applies | ✅ `pk = id,nid` |
| **Two scopes each seed 4 built-ins** | ✅ 4 / 4 |
| Delete `todo` in scope A | ✅ A=0, **B untouched** |
| Rename `complete` in scope B | ✅ B="Shipped", **A="Complete"** |
| `task_column_get_v2` | ✅ exactly 1 row |
| `task_update_status` regression | ✅ |
| Migration idempotent (re-run) | ✅ |
| Row count after migration | ✅ unchanged, no data loss |

## Not in this PR — needed before the ALTER can be applied

- **server**: `task.js` + `acl/task.json` to call `task_column_get_v2` / `_update_v2` / `_delete_v2`, passing the folder nid.
- **ui**: pass `nid` on those calls.

Until that lands, applying only the `_v2` procs is safe (nothing calls them); **the ALTER must wait.**

## Known limitation

The marker purge cannot distinguish a scope poisoned by a swallowed INSERT from one where the user genuinely deleted all four built-ins — no flag or timestamp separates them — so such a board is re-seeded on next open. Scopes retaining even one built-in are untouched, so ordinary single-column deletes still persist.

## Related

A UI-side mitigation is on `test` (ui-team `73f5871b`): the board falls back to built-in placeholders when a scope has no stored built-in row. It fixes the hidden-tasks symptom without any DB change and stops triggering once scopes seed correctly. Independent of this PR.
