### PR TITLE
fix(task): guard the is_done patch on the task_column TABLE, not just the column

### DIFF
--- a/common/patches/alter_task_column_add_is_done.sql
+++ b/common/patches/alter_task_column_add_is_done.sql
@@ -4,6 +4,15 @@
 -- replaces the previous hardcoded reliance on the literal status key 'complete',
 -- so the four built-in columns can now be renamed / recoloured / reordered /
 -- deleted like any custom column without breaking completion tracking.
+-- Guard on the TABLE, not just the column: a database with no task_column at
+-- all would otherwise take the @c = 0 branch, attempt the ALTER and die with
+-- ER_NO_SUCH_TABLE (1146) — which patch.js treats as fatal and aborts the whole
+-- fleet run on. 156 of 748 stage databases have no task_column, so this file
+-- could never complete there.
+SET @has_tc := (
+  SELECT COUNT(*) FROM information_schema.TABLES
+   WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'task_column'
+);
 SET @c := (
   SELECT COUNT(*) FROM information_schema.COLUMNS
    WHERE TABLE_SCHEMA = DATABASE()
@@ -11,7 +20,7 @@ SET @c := (
      AND COLUMN_NAME = 'is_done'
 );
 SET @s := IF(
-  @c = 0,
+  @has_tc = 1 AND @c = 0,
   'ALTER TABLE task_column ADD COLUMN is_done TINYINT(1) NOT NULL DEFAULT 0 AFTER position',
   'DO 0'
 );
@@ -19,4 +28,10 @@ PREPARE st FROM @s; EXECUTE st; DEALLOCATE PREPARE st;
 
 -- Backfill: an already-seeded built-in 'complete' column (from before this flag
 -- existed) must become the done column so existing boards keep working.
-UPDATE task_column SET is_done = 1 WHERE id = 'complete' AND is_done = 0;
+-- Guarded for the same reason as the ALTER above.
+SET @s := IF(
+  @has_tc = 1,
+  'UPDATE task_column SET is_done = 1 WHERE id = ''complete'' AND is_done = 0',
+  'DO 0'
+);
+PREPARE st FROM @s; EXECUTE st; DEALLOCATE PREPARE st;


### PR DESCRIPTION
Found while applying the task-column scope fix to stage.

## Problem

`alter_task_column_add_is_done.sql` guards on whether the **column** exists, not the **table**. A database with no `task_column` at all takes the `@c = 0` branch, attempts the ALTER and dies with `ER_NO_SUCH_TABLE` (1146). `patch.js` treats that as fatal and **aborts the entire fleet run** at that database.

On stage, **156 of 748** common databases have no `task_column`, so the file could never complete — `is_done` was left on only **510 of 599** tables.

Procs that select `is_done` (`task_column_list`, `task_column_get`, and now `task_column_create`) then fail on the remainder. The DB layer swallows SQL errors and returns empty, so the service surfaced it as **400 `COLUMN_CREATE_FAILED`** on drumee.in.

**Prod was never affected** — all 11,333 databases there already have the table, which is why the original fleet apply reported 11,333/11,333.

## Fix

Guards both the ALTER and the backfill UPDATE on table existence, matching the pattern used in `alter_task_column_scope_pk.sql`.

## Verification

On throwaway databases (dropped after):

| Case | Result |
|---|---|
| DB with **no** `task_column` | rc=0 — clean no-op, no longer aborts |
| `task_column` without `is_done` | column added; `complete` backfilled to `is_done=1`, custom stays 0 |
| Re-run (idempotence) | rc=0, values unchanged |

Then re-applied to stage: **592/592** target tables now have `is_done`, zero errors, 156 table-less DBs skipped gracefully.

## Note

This is independent of #74 — the bug predates it. #74 only made it visible, because `task_column_create` now selects `is_done` too.