### PR TITLE
chore: promote test → preview (task patch table guards)

### DIFF
--- a/common/patches/alter_task_add_fields.sql
+++ b/common/patches/alter_task_add_fields.sql
@@ -9,6 +9,16 @@
 -- ---------------------------------------------------------------------------
 -- task.description
 -- ---------------------------------------------------------------------------
+-- Guarded on the TABLE as well as the column: information_schema.COLUMNS
+-- returns 0 both when the column is missing AND when the table itself is
+-- missing, so the original guard took the "apply" branch on a database with no
+-- `task` table and died with ER_NO_SUCH_TABLE (1146) — which patch.js treats
+-- as fatal, aborting the whole fleet run at that database.
+SET @has_tbl := (
+  SELECT COUNT(*) FROM information_schema.TABLES
+   WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'task'
+);
+
 SET @col_exists = (
   SELECT COUNT(*)
   FROM information_schema.COLUMNS
@@ -18,7 +28,7 @@ SET @col_exists = (
 );
 
 SET @sql = IF(
-  @col_exists = 0,
+  @has_tbl = 1 AND @col_exists = 0,
   'ALTER TABLE `task` ADD COLUMN `description` TEXT NULL AFTER `title`',
   'SELECT "task.description column already exists — skipped" AS info'
 );
@@ -39,7 +49,7 @@ SET @col_exists = (
 );
 
 SET @sql = IF(
-  @col_exists = 0,
+  @has_tbl = 1 AND @col_exists = 0,
   'ALTER TABLE `task` ADD COLUMN `priority` ENUM(''low'',''medium'',''high'',''urgent'') NOT NULL DEFAULT ''medium'' AFTER `status`',
   'SELECT "task.priority column already exists — skipped" AS info'
 );
@@ -60,7 +70,7 @@ SET @idx_exists = (
 );
 
 SET @sql = IF(
-  @idx_exists = 0,
+  @has_tbl = 1 AND @idx_exists = 0,
   'ALTER TABLE `task` ADD KEY `idx_priority` (`priority`)',
   'SELECT "task.idx_priority already exists — skipped" AS info'
 );
@@ -81,7 +91,7 @@ SET @col_exists = (
 );
 
 SET @sql = IF(
-  @col_exists = 0,
+  @has_tbl = 1 AND @col_exists = 0,
   'ALTER TABLE `task` ADD COLUMN `assignee_uid` VARCHAR(16) CHARACTER SET ascii COLLATE ascii_general_ci NULL AFTER `created_by`',
   'SELECT "task.assignee_uid column already exists — skipped" AS info'
 );
@@ -102,7 +112,7 @@ SET @idx_exists = (
 );
 
 SET @sql = IF(
-  @idx_exists = 0,
+  @has_tbl = 1 AND @idx_exists = 0,
   'ALTER TABLE `task` ADD KEY `idx_assignee_uid` (`assignee_uid`)',
   'SELECT "task.idx_assignee_uid already exists — skipped" AS info'
 );

--- a/common/patches/alter_task_add_rank.sql
+++ b/common/patches/alter_task_add_rank.sql
@@ -13,18 +13,35 @@
 -- Apply to every common-class DB individually, e.g.:
 --   bin/patch-from-file common/patches/alter_task_add_rank.sql common
 
-ALTER TABLE `task`
-  ADD COLUMN IF NOT EXISTS `rank` INT(11) NOT NULL DEFAULT 0 AFTER `nid`;
+-- Guarded on the table: not every common-class database has a `task` table,
+-- and an unguarded statement there dies with ER_NO_SUCH_TABLE (1146), which
+-- patch.js treats as fatal — aborting the whole fleet run at that database.
+SET @has_task := (
+  SELECT COUNT(*) FROM information_schema.TABLES
+   WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'task'
+);
+
+SET @sql := IF(
+  @has_task = 1,
+  'ALTER TABLE `task` ADD COLUMN IF NOT EXISTS `rank` INT(11) NOT NULL DEFAULT 0 AFTER `nid`',
+  'DO 0'
+);
+PREPARE st FROM @sql; EXECUTE st; DEALLOCATE PREPARE st;
 
 -- Backfill: give pre-existing tasks a stable per-(folder, column) rank that
 -- matches the legacy display order (creation time), so existing boards keep
 -- their ordering instead of every task sharing rank 0. Only touches rank = 0
 -- rows, so re-runs and already-ranked tasks are unaffected.
-UPDATE task t
-  JOIN (
-    SELECT id,
-           ROW_NUMBER() OVER (PARTITION BY nid, status ORDER BY ctime, id) AS rn
-      FROM task
-  ) r ON r.id = t.id
-   SET t.`rank` = r.rn
- WHERE t.`rank` = 0;
+SET @sql := IF(
+  @has_task = 1,
+  'UPDATE task t
+     JOIN (
+       SELECT id,
+              ROW_NUMBER() OVER (PARTITION BY nid, status ORDER BY ctime, id) AS rn
+         FROM task
+     ) r ON r.id = t.id
+      SET t.`rank` = r.rn
+    WHERE t.`rank` = 0',
+  'DO 0'
+);
+PREPARE st FROM @sql; EXECUTE st; DEALLOCATE PREPARE st;

--- a/common/patches/alter_task_comment_threads_reactions.sql
+++ b/common/patches/alter_task_comment_threads_reactions.sql
@@ -11,6 +11,16 @@
 -- ---------------------------------------------------------------------------
 -- task_comment.parent_id
 -- ---------------------------------------------------------------------------
+-- Guarded on the TABLE as well as the column: information_schema.COLUMNS
+-- returns 0 both when the column is missing AND when the table itself is
+-- missing, so the original guard took the "apply" branch on a database with no
+-- `task_comment` table and died with ER_NO_SUCH_TABLE (1146) — which patch.js treats
+-- as fatal, aborting the whole fleet run at that database.
+SET @has_tbl := (
+  SELECT COUNT(*) FROM information_schema.TABLES
+   WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'task_comment'
+);
+
 SET @col_exists = (
   SELECT COUNT(*)
   FROM information_schema.COLUMNS
@@ -20,7 +30,7 @@ SET @col_exists = (
 );
 
 SET @sql = IF(
-  @col_exists = 0,
+  @has_tbl = 1 AND @col_exists = 0,
   'ALTER TABLE `task_comment` ADD COLUMN `parent_id` VARCHAR(16) CHARACTER SET ascii COLLATE ascii_general_ci NULL AFTER `author_uid`, ADD KEY `idx_parent` (`parent_id`)',
   'SELECT "task_comment.parent_id already exists — skipped" AS info'
 );

--- a/common/patches/alter_task_custom_columns.sql
+++ b/common/patches/alter_task_custom_columns.sql
@@ -11,9 +11,22 @@
 
 -- ---------------------------------------------------------------------------
 -- task.status: enum → varchar
+--
+-- Guarded on the table: not every common-class database has a `task` table,
+-- and an unguarded statement there dies with ER_NO_SUCH_TABLE (1146), which
+-- patch.js treats as fatal — aborting the whole fleet run at that database.
+-- The CREATE TABLE below needs no guard (IF NOT EXISTS).
 -- ---------------------------------------------------------------------------
-ALTER TABLE `task`
-  MODIFY `status` VARCHAR(32) NOT NULL DEFAULT 'todo';
+SET @has_task := (
+  SELECT COUNT(*) FROM information_schema.TABLES
+   WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'task'
+);
+SET @sql := IF(
+  @has_task = 1,
+  'ALTER TABLE `task` MODIFY `status` VARCHAR(32) NOT NULL DEFAULT ''todo''',
+  'DO 0'
+);
+PREPARE st FROM @sql; EXECUTE st; DEALLOCATE PREPARE st;
 
 -- ---------------------------------------------------------------------------
 -- task_column — user-created Kanban columns

--- a/common/patches/alter_task_folder_scope_and_multi_assignee.sql
+++ b/common/patches/alter_task_folder_scope_and_multi_assignee.sql
@@ -16,6 +16,16 @@
 -- ---------------------------------------------------------------------------
 -- task.nid
 -- ---------------------------------------------------------------------------
+-- Guarded on the TABLE as well as the column: information_schema.COLUMNS
+-- returns 0 both when the column is missing AND when the table itself is
+-- missing, so the original guard took the "apply" branch on a database with no
+-- `task` table and died with ER_NO_SUCH_TABLE (1146) — which patch.js treats
+-- as fatal, aborting the whole fleet run at that database.
+SET @has_tbl := (
+  SELECT COUNT(*) FROM information_schema.TABLES
+   WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'task'
+);
+
 SET @col_exists = (
   SELECT COUNT(*)
   FROM information_schema.COLUMNS
@@ -25,7 +35,7 @@ SET @col_exists = (
 );
 
 SET @sql = IF(
-  @col_exists = 0,
+  @has_tbl = 1 AND @col_exists = 0,
   'ALTER TABLE `task` ADD COLUMN `nid` VARCHAR(16) CHARACTER SET ascii COLLATE ascii_general_ci NULL AFTER `assignee_uid`',
   'SELECT "task.nid column already exists — skipped" AS info'
 );
@@ -46,7 +56,7 @@ SET @idx_exists = (
 );
 
 SET @sql = IF(
-  @idx_exists = 0,
+  @has_tbl = 1 AND @idx_exists = 0,
   'ALTER TABLE `task` ADD KEY `idx_nid` (`nid`)',
   'SELECT "task.idx_nid already exists — skipped" AS info'
 );
@@ -71,11 +81,25 @@ CREATE TABLE IF NOT EXISTS `task_assignee` (
 -- INSERT IGNORE keeps this idempotent (re-runnable) — already-migrated rows
 -- collide on the PK and are skipped.
 -- ---------------------------------------------------------------------------
-INSERT IGNORE INTO `task_assignee` (`task_id`, `uid`, `ctime`)
-SELECT t.id, t.assignee_uid, IFNULL(t.ctime, UNIX_TIMESTAMP())
-  FROM `task` t
- WHERE t.assignee_uid IS NOT NULL
-   AND t.assignee_uid <> '';
+-- Guarded: reads from `task`, which does not exist in every common-class DB.
+-- Also requires assignee_uid — on a database where the earlier ALTER was
+-- skipped the column is absent and the SELECT would fail.
+SET @has_assignee_col := (
+  SELECT COUNT(*) FROM information_schema.COLUMNS
+   WHERE TABLE_SCHEMA = DATABASE()
+     AND TABLE_NAME   = 'task'
+     AND COLUMN_NAME  = 'assignee_uid'
+);
+SET @sql := IF(
+  @has_tbl = 1 AND @has_assignee_col = 1,
+  'INSERT IGNORE INTO `task_assignee` (`task_id`, `uid`, `ctime`)
+   SELECT t.id, t.assignee_uid, IFNULL(t.ctime, UNIX_TIMESTAMP())
+     FROM `task` t
+    WHERE t.assignee_uid IS NOT NULL
+      AND t.assignee_uid <> ''''',
+  'DO 0'
+);
+PREPARE st FROM @sql; EXECUTE st; DEALLOCATE PREPARE st;
 
 -- The single-assignee proc is replaced by task_set_assignees (multi). Drop the
 -- orphan so deployed hub DBs don't keep a stale procedure around.

--- a/common/patches/alter_task_health_metrics.sql
+++ b/common/patches/alter_task_health_metrics.sql
@@ -9,16 +9,32 @@
 
 -- ---------------------------------------------------------------------------
 -- task.completed_at
+--
+-- Guarded on the table: not every common-class database has a `task` table,
+-- and an unguarded statement there dies with ER_NO_SUCH_TABLE (1146), which
+-- patch.js treats as fatal — aborting the whole fleet run at that database.
+-- The CREATE TABLE below needs no guard (IF NOT EXISTS).
 -- ---------------------------------------------------------------------------
-ALTER TABLE `task`
-  ADD COLUMN IF NOT EXISTS `completed_at` INT(11) NOT NULL DEFAULT 0 AFTER `mtime`;
+SET @has_task := (
+  SELECT COUNT(*) FROM information_schema.TABLES
+   WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'task'
+);
+
+SET @sql := IF(
+  @has_task = 1,
+  'ALTER TABLE `task` ADD COLUMN IF NOT EXISTS `completed_at` INT(11) NOT NULL DEFAULT 0 AFTER `mtime`',
+  'DO 0'
+);
+PREPARE st FROM @sql; EXECUTE st; DEALLOCATE PREPARE st;
 
 -- Backfill: tasks already in 'complete' get their mtime as a best-effort
 -- completion time (the real moment is unknown for pre-migration rows).
-UPDATE `task`
-   SET `completed_at` = `mtime`
- WHERE `status` = 'complete'
-   AND `completed_at` = 0;
+SET @sql := IF(
+  @has_task = 1,
+  'UPDATE `task` SET `completed_at` = `mtime` WHERE `status` = ''complete'' AND `completed_at` = 0',
+  'DO 0'
+);
+PREPARE st FROM @sql; EXECUTE st; DEALLOCATE PREPARE st;
 
 -- ---------------------------------------------------------------------------
 -- task_activity — folder-scoped activity feed


### PR DESCRIPTION
Whole-branch promotion `test` → `preview`. `origin/preview` was backmerged into `test` first (no conflicts), so this is a clean superset. All six guards verified intact after the backmerge.

Carries **#77** — every task patch now guards on the target **table**, not just the column.

## Why

`information_schema.COLUMNS` returns 0 both when the column is missing and when the table is missing, so `IF(@col_exists = 0, 'ALTER …', 'DO 0')` took the *apply* branch on a database with no `task` table and died with `ER_NO_SUCH_TABLE` (1146). `patch.js` treats that as fatal and **aborts the whole fleet run** at that database.

That is how `alter_task_column_add_is_done` stalled on stage today: 156 of 748 databases have no `task_column`, the run died partway, and `is_done` was left on only 510 of 599 tables — surfacing as **400 COLUMN_CREATE_FAILED** with no stack trace, because the DB layer swallows SQL errors.

## Risk: none

**Behaviour on databases that have the tables is byte-identical** — this only converts a fatal abort into a skip. **No DB re-apply is needed**, on prod or stage; it is purely protection for future fleet runs. Prod is already at 11,333/11,333 on every task object.

## Verification

Throwaway databases, dropped afterwards: all 11 patches are clean no-ops on an empty database (previously an abort); on a faithful pre-migration `task` table all 11 apply with rows intact and `completed_at` / `rank` backfilled correctly; re-running every file is idempotent.

## Deploy

**No prod action required.** Schemas has no CI, and this needs no DB apply.