### PR TITLE
feat(pricing): USD catalog — Pro (B2C) retired in favour of Team (B2B)

### DIFF
--- a/drumate/procedures/notification/notification_center_next.sql
+++ b/drumate/procedures/notification/notification_center_next.sql
@@ -34,14 +34,26 @@ DECLARE _wicket_id VARCHAR(16);
       -- category). Lets a single-file upload rollup (cnt = 1) show the file name
       -- instead of its destination folder. For cnt > 1 it is ignored and the
       -- folder/workspace name is shown.
-      item_filename VARCHAR(128)
+      item_filename VARCHAR(128),
+      -- The team-chat message author (its poster). NULL for every non-teamchat
+      -- category. The teamchat rollup used entity_id = the FOLDER id, so the
+      -- final SELECT's identity joins never matched a user → name/avatar came
+      -- back empty and the client showed "Someone posted…" with the viewer's own
+      -- face. Carrying the real author here lets the rollup resolve the poster's
+      -- name (yp.drumate `da` join below) and the client resolve the avatar.
+      author_id VARCHAR(16) CHARACTER SET ascii,
+      -- 'start' | 'end' for a [[MEETING:...]] system chat message, else NULL.
+      -- Drives the "started/ended a meeting in <folder>" wording. A meeting event
+      -- takes priority over plain chat in the per-folder rollup (see the aggregate
+      -- below), so a start/end is never masked by a later ordinary message.
+      meeting_action VARCHAR(8)
 
    );
 
 
    INSERT INTO _show_node
    SELECT
-      ci.id  ,d.id ,_uid , NULL, NULL, NULL, NULL, NULL, NULL, mtime,'personal' ,'contact', NULL
+      ci.id  ,d.id ,_uid , NULL, NULL, NULL, NULL, NULL, NULL, mtime,'personal' ,'contact', NULL, NULL, NULL
    FROM
    contact ci
    INNER JOIN yp.drumate d ON d.id = ci.entity
@@ -63,7 +75,7 @@ DECLARE _wicket_id VARCHAR(16);
    -- appeared (and could not be dismissed).
    INSERT INTO _show_node
    SELECT
-      pt.peer_id, pt.peer_id, _uid, NULL, NULL, NULL, NULL, NULL, pt.ref_ctime, pt.ref_ctime, 'personal', 'chat', NULL
+      pt.peer_id, pt.peer_id, _uid, NULL, NULL, NULL, NULL, NULL, pt.ref_ctime, pt.ref_ctime, 'personal', 'chat', NULL, NULL, NULL
    FROM
       p2p_time pt
    INNER JOIN yp.drumate du ON du.id = pt.peer_id
@@ -104,12 +116,12 @@ DECLARE _wicket_id VARCHAR(16);
       IF _db_name IS NOT NULL AND _area IS NOT NULL THEN
       SET @sql=  CONCAT(
          "INSERT INTO _show_node
-         SELECT c.message_id,'", _nid ,"','",_nid, "' As hub_id , JSON_UNQUOTE(JSON_EXTRACT(c.metadata,'$._scope_nid')), sf.parent_id, sf.user_filename, 'folder', NULL, c.sys_id, c.ctime,'", _area, "','teamchat', NULL  FROM ", _db_name ,".channel c LEFT JOIN ", _db_name ,".media sf ON sf.id = JSON_UNQUOTE(JSON_EXTRACT(c.metadata,'$._scope_nid')) WHERE c.status='active' AND c.author_id <> '", _uid ,"' AND JSON_EXISTS(c.metadata,'$._delivered_.", _uid ,"')=1 AND JSON_EXISTS(c.metadata,'$._seen_.", _uid ,"')=0 AND c.file_thread_id IS NULL" ) ;
+         SELECT c.message_id,'", _nid ,"','",_nid, "' As hub_id , JSON_UNQUOTE(JSON_EXTRACT(c.metadata,'$._scope_nid')), sf.parent_id, sf.user_filename, 'folder', NULL, c.sys_id, c.ctime,'", _area, "','teamchat', NULL, c.author_id, CASE WHEN c.message LIKE '[[MEETING:start:%' THEN 'start' WHEN c.message LIKE '[[MEETING:end:%' THEN 'end' ELSE NULL END  FROM ", _db_name ,".channel c LEFT JOIN ", _db_name ,".media sf ON sf.id = JSON_UNQUOTE(JSON_EXTRACT(c.metadata,'$._scope_nid')) WHERE c.status='active' AND c.author_id <> '", _uid ,"' AND JSON_EXISTS(c.metadata,'$._delivered_.", _uid ,"')=1 AND JSON_EXISTS(c.metadata,'$._seen_.", _uid ,"')=0 AND c.file_thread_id IS NULL" ) ;
       EXECUTE IMMEDIATE @sql;
 
       SET @s = CONCAT(
           " INSERT INTO _show_node
-            SELECT m.id, m.owner_id, '" , _nid , "', target.id, target.parent_id, target.user_filename, 'folder', m.category, m.sys_id, m.upload_time,'", _area ,"','media', m.user_filename FROM ", _db_name ,
+            SELECT m.id, m.owner_id, '" , _nid , "', target.id, target.parent_id, target.user_filename, 'folder', m.category, m.sys_id, m.upload_time,'", _area ,"','media', m.user_filename, NULL, NULL FROM ", _db_name ,
           ".media m LEFT JOIN ", _db_name ,".media target ON target.id = IF(m.category = 'folder', m.id, m.parent_id) WHERE m.file_path not REGEXP '^/__(chat|trash)__'  AND m.category != 'root' AND
             IFNULL((is_new(m.metadata, m.owner_id, ?)), 0) =1 "
         );
@@ -147,7 +159,7 @@ DECLARE _wicket_id VARCHAR(16);
       SET @s = CONCAT("
             INSERT INTO _show_node
             SELECT
-               t.ticket_id  , t.ticket_id , 'Support Ticket', NULL,NULL,NULL,NULL,NULL, c.sys_id, c.ctime ,'personal','ticket', NULL
+               t.ticket_id  , t.ticket_id , 'Support Ticket', NULL,NULL,NULL,NULL,NULL, c.sys_id, c.ctime ,'personal','ticket', NULL, NULL, NULL
             FROM
                yp.ticket t
             INNER JOIN ", _wicket_db_name ,". map_ticket mt  ON  mt.ticket_id = t.ticket_id
@@ -165,7 +177,7 @@ DECLARE _wicket_id VARCHAR(16);
 
       INSERT INTO _show_node
       SELECT
-         t.ticket_id,  t.ticket_id ,'Support Ticket', NULL,NULL,NULL,NULL,NULL,NULL,c.ctime ,'personal','ticket', NULL
+         t.ticket_id,  t.ticket_id ,'Support Ticket', NULL,NULL,NULL,NULL,NULL,NULL,c.ctime ,'personal','ticket', NULL, NULL, NULL
       FROM
          yp.ticket t
       LEFT JOIN yp.read_ticket_channel rtc on rtc.ticket_id = t.ticket_id AND rtc.uid = _uid
@@ -208,6 +220,15 @@ DECLARE _wicket_id VARCHAR(16);
       b.category,
       b.cnt,
       b.area,
+      -- Actor identity for team-chat rollups (NULL for other categories). The
+      -- server maps author_id/author_firstname/author_lastname and the client
+      -- prefers them for both the sender name and the avatar, so this fixes both
+      -- "Someone posted…" and the wrong (viewer's own) avatar. meeting_action lets
+      -- the client render "started/ended a meeting in <folder>".
+      b.author_id author_id,
+      da.firstname author_firstname,
+      da.lastname author_lastname,
+      b.meeting_action meeting_action,
 
       (SELECT GROUP_CONCAT(t.tag_id) FROM
       tag t INNER JOIN map_tag mt ON t.tag_id = mt.tag_id
@@ -221,13 +242,31 @@ DECLARE _wicket_id VARCHAR(16);
       MAX(filetype) filetype,
       MAX(item_filetype) item_filetype,
       MAX(last_id) last_id,
-      MAX(item_filename) item_filename
+      MAX(item_filename) item_filename,
+      -- Meeting takes priority: the LATEST [[MEETING]] event's action for this
+      -- folder if any exists, else NULL. GROUP_CONCAT skips NULLs, so this is the
+      -- newest non-null meeting_action — a later ordinary chat message cannot mask
+      -- a start/end. group_concat_max_len truncation is harmless: we only read the
+      -- first (newest) element via SUBSTRING_INDEX.
+      SUBSTRING_INDEX(GROUP_CONCAT(meeting_action ORDER BY ctime DESC, last_id DESC),',',1) meeting_action,
+      -- Actor for the rollup. When a meeting exists → the latest meeting event's
+      -- author (so "<X> started/ended a meeting"); otherwise the latest message's
+      -- author (so "<X> posted"). last_id (channel sys_id) is unique per message,
+      -- so the shared ORDER BY is deterministic and this pick agrees with
+      -- meeting_action above. NULL for non-teamchat groups (author_id all NULL).
+      COALESCE(
+        SUBSTRING_INDEX(GROUP_CONCAT(IF(meeting_action IS NOT NULL, author_id, NULL) ORDER BY ctime DESC, last_id DESC),',',1),
+        SUBSTRING_INDEX(GROUP_CONCAT(author_id ORDER BY ctime DESC, last_id DESC),',',1)
+      ) author_id
    FROM  _show_node
    GROUP BY entity_id,hub_id,category,area,nid ) b
 
    LEFT JOIN yp.hub h ON h.id = b.hub_id
    LEFT JOIN yp.dmz_user dmu ON b.entity_id = dmu.id
    LEFT JOIN yp.drumate d ON b.entity_id = d.id
+   -- Resolve the team-chat actor's canonical name from the author_id picked in the
+   -- aggregate above (separate alias from `d`, which joins on entity_id = folder).
+   LEFT JOIN yp.drumate da ON da.id = b.author_id
    LEFT JOIN contact c ON  b.entity_id = c.uid  OR  b.entity_id = c.entity
    LEFT JOIN contact_email ce ON ce.contact_id = c.id   AND ce.is_default = 1
    ORDER BY b.ctime DESC;

--- a/drumate/procedures/notification/notification_center_next.sql
+++ b/drumate/procedures/notification/notification_center_next.sql
@@ -29,14 +29,19 @@ DECLARE _wicket_id VARCHAR(16);
       last_id INT(11) UNSIGNED,
       ctime  INT(11) ,
       area  VARCHAR(16),
-      category VARCHAR(16)
+      category VARCHAR(16),
+      -- The uploaded FILE's own name (media rows only; NULL for every other
+      -- category). Lets a single-file upload rollup (cnt = 1) show the file name
+      -- instead of its destination folder. For cnt > 1 it is ignored and the
+      -- folder/workspace name is shown.
+      item_filename VARCHAR(128)
 
    );
 
 
    INSERT INTO _show_node
    SELECT
-      ci.id  ,d.id ,_uid , NULL, NULL, NULL, NULL, NULL, NULL, mtime,'personal' ,'contact'
+      ci.id  ,d.id ,_uid , NULL, NULL, NULL, NULL, NULL, NULL, mtime,'personal' ,'contact', NULL
    FROM
    contact ci
    INNER JOIN yp.drumate d ON d.id = ci.entity
@@ -58,7 +63,7 @@ DECLARE _wicket_id VARCHAR(16);
    -- appeared (and could not be dismissed).
    INSERT INTO _show_node
    SELECT
-      pt.peer_id, pt.peer_id, _uid, NULL, NULL, NULL, NULL, NULL, pt.ref_ctime, pt.ref_ctime, 'personal', 'chat'
+      pt.peer_id, pt.peer_id, _uid, NULL, NULL, NULL, NULL, NULL, pt.ref_ctime, pt.ref_ctime, 'personal', 'chat', NULL
    FROM
       p2p_time pt
    INNER JOIN yp.drumate du ON du.id = pt.peer_id
@@ -99,12 +104,12 @@ DECLARE _wicket_id VARCHAR(16);
       IF _db_name IS NOT NULL AND _area IS NOT NULL THEN
       SET @sql=  CONCAT(
          "INSERT INTO _show_node
-         SELECT c.message_id,'", _nid ,"','",_nid, "' As hub_id , JSON_UNQUOTE(JSON_EXTRACT(c.metadata,'$._scope_nid')), sf.parent_id, sf.user_filename, 'folder', NULL, c.sys_id, c.ctime,'", _area, "','teamchat'  FROM ", _db_name ,".channel c LEFT JOIN ", _db_name ,".media sf ON sf.id = JSON_UNQUOTE(JSON_EXTRACT(c.metadata,'$._scope_nid')) WHERE c.status='active' AND c.author_id <> '", _uid ,"' AND JSON_EXISTS(c.metadata,'$._delivered_.", _uid ,"')=1 AND JSON_EXISTS(c.metadata,'$._seen_.", _uid ,"')=0 AND c.file_thread_id IS NULL" ) ;
+         SELECT c.message_id,'", _nid ,"','",_nid, "' As hub_id , JSON_UNQUOTE(JSON_EXTRACT(c.metadata,'$._scope_nid')), sf.parent_id, sf.user_filename, 'folder', NULL, c.sys_id, c.ctime,'", _area, "','teamchat', NULL  FROM ", _db_name ,".channel c LEFT JOIN ", _db_name ,".media sf ON sf.id = JSON_UNQUOTE(JSON_EXTRACT(c.metadata,'$._scope_nid')) WHERE c.status='active' AND c.author_id <> '", _uid ,"' AND JSON_EXISTS(c.metadata,'$._delivered_.", _uid ,"')=1 AND JSON_EXISTS(c.metadata,'$._seen_.", _uid ,"')=0 AND c.file_thread_id IS NULL" ) ;
       EXECUTE IMMEDIATE @sql;
 
       SET @s = CONCAT(
           " INSERT INTO _show_node
-            SELECT m.id, m.owner_id, '" , _nid , "', target.id, target.parent_id, target.user_filename, 'folder', m.category, m.sys_id, m.upload_time,'", _area ,"','media' FROM ", _db_name ,
+            SELECT m.id, m.owner_id, '" , _nid , "', target.id, target.parent_id, target.user_filename, 'folder', m.category, m.sys_id, m.upload_time,'", _area ,"','media', m.user_filename FROM ", _db_name ,
           ".media m LEFT JOIN ", _db_name ,".media target ON target.id = IF(m.category = 'folder', m.id, m.parent_id) WHERE m.file_path not REGEXP '^/__(chat|trash)__'  AND m.category != 'root' AND
             IFNULL((is_new(m.metadata, m.owner_id, ?)), 0) =1 "
         );
@@ -142,7 +147,7 @@ DECLARE _wicket_id VARCHAR(16);
       SET @s = CONCAT("
             INSERT INTO _show_node
             SELECT
-               t.ticket_id  , t.ticket_id , 'Support Ticket', NULL,NULL,NULL,NULL,NULL, c.sys_id, c.ctime ,'personal','ticket'
+               t.ticket_id  , t.ticket_id , 'Support Ticket', NULL,NULL,NULL,NULL,NULL, c.sys_id, c.ctime ,'personal','ticket', NULL
             FROM
                yp.ticket t
             INNER JOIN ", _wicket_db_name ,". map_ticket mt  ON  mt.ticket_id = t.ticket_id
@@ -160,7 +165,7 @@ DECLARE _wicket_id VARCHAR(16);
 
       INSERT INTO _show_node
       SELECT
-         t.ticket_id,  t.ticket_id ,'Support Ticket', NULL,NULL,NULL,NULL,NULL,NULL,c.ctime ,'personal','ticket'
+         t.ticket_id,  t.ticket_id ,'Support Ticket', NULL,NULL,NULL,NULL,NULL,NULL,c.ctime ,'personal','ticket', NULL
       FROM
          yp.ticket t
       LEFT JOIN yp.read_ticket_channel rtc on rtc.ticket_id = t.ticket_id AND rtc.uid = _uid
@@ -185,9 +190,18 @@ DECLARE _wicket_id VARCHAR(16);
       b.hub_id hub_id,
       b.nid,
       b.parent_id,
-      b.filename,
+      -- Display name for the rollup. For a media upload into the workspace ROOT
+      -- the destination "folder" is the root node, whose user_filename is empty
+      -- (NULL on some instances, '' on others) — so b.filename is blank and the
+      -- client used to fall back through surname to the UPLOADER'S EMAIL. Fall
+      -- back to the workspace name (h.name) so a root upload reads "…in
+      -- <Workspace>" instead of the uploader email. NULLIF collapses the ''
+      -- variant to NULL so COALESCE catches it too. For contact/chat/ticket rows
+      -- b.hub_id is NULL → h.name is NULL → no change.
+      COALESCE(NULLIF(b.filename, ''), h.name) filename,
       b.filetype,
       b.item_filetype,
+      b.item_filename,
       b.last_id,
 
       b.ctime,
@@ -206,7 +220,8 @@ DECLARE _wicket_id VARCHAR(16);
       MAX(filename) filename,
       MAX(filetype) filetype,
       MAX(item_filetype) item_filetype,
-      MAX(last_id) last_id
+      MAX(last_id) last_id,
+      MAX(item_filename) item_filename
    FROM  _show_node
    GROUP BY entity_id,hub_id,category,area,nid ) b
 

--- a/patches/changelog.txt
+++ b/patches/changelog.txt
@@ -1,3 +1,23 @@
+2026-07-24 (pricing rebuild — the catalog moves to USD and the B2C `pro` tier
+  gives way to the B2B `team` tier. FREE $0/5GB solo, TEAM $29/100GB/<=10
+  members, BUSINESS $99/1TB/unlimited (sales-led, no Stripe price); yearly is
+  11 x monthly, so team $319 and business $1089. Sovereign is self-hosted and
+  sales-led, so it is not a SaaS entitlement and has no row. Team also stops
+  being per-seat: quota.$.disk is now the whole allowance and quota.$.seat is
+  the member CAP, so payment_apply_entitlement no longer multiplies by the
+  subscription quantity nor overwrites $.seat -- the catalog rows and that
+  procedure must move together or org disk goes wrong. `pro`, the add-ons
+  (pro_seat, storage_*) and every EUR row are DEACTIVATED, not deleted, so
+  subscription/renewal history still resolves its plan row; a Stripe price's
+  currency cannot be changed, hence new USD rows rather than an update. Legacy
+  hand-granted quota rows ('Pro', 'Drumee Plus', 'advanced') move onto the Team
+  entitlement, but only where source <> 'stripe', so nothing a customer is
+  paying for is rewritten.)
+  yellow_page/patches/2026-07-24-pricing-usd-team-business.sql
+  yellow_page/tables/plan.sql
+  yellow_page/procedures/subscription/payment_apply_entitlement.sql
+  yellow_page/procedures/subscription/payment_get_catalog.sql
+
 2026-07-23 (upload notification — root uploads showed the uploader email; fall
   back to the workspace name + carry the file name for single uploads)
   drumate/procedures/notification/notification_center_next.sql

--- a/patches/changelog.txt
+++ b/patches/changelog.txt
@@ -1,3 +1,21 @@
+2026-07-24 (pricing migration follow-ups. Two gaps the first pricing patch left:
+  org rows already named 'team' kept the PRE-REBUILD per-seat allowance, because
+  that patch only rewrote rows whose plan was a retired NAME -- under the old
+  model 'team' was per seat and payment_apply_entitlement stored per-seat disk x
+  seats, typically a bare 50 GB, so those orgs read as Team while holding half
+  the storage the plan now grants, correcting only on their next renewal. And
+  'free' rows kept the old 20 GB, four times the new allowance. The org backfill
+  ONLY EVER RAISES -- disk comes from the active catalog row and applies solely
+  where the stored value is lower, so an org holding more keeps it (verified on
+  stage: 29 rows went 50 GB -> 100 GB, one legitimately on 250 GB untouched).
+  The free migration is the only one that REDUCES, so it is guarded by live
+  usage: a row is lowered only when the domain's actual_usage still fits 5 GB,
+  and accounts above it are listed by a trailing SELECT for a human decision
+  rather than silently pushed over quota -- on stage one of five such accounts
+  was storing 13 GB.)
+  yellow_page/patches/2026-07-24-backfill-org-team-disk.sql
+  yellow_page/patches/2026-07-24-migrate-free-to-new-allowance.sql
+
 2026-07-24 (pricing rebuild — the catalog moves to USD and the B2C `pro` tier
   gives way to the B2B `team` tier. FREE $0/5GB solo, TEAM $29/100GB/<=10
   members, BUSINESS $99/1TB/unlimited (sales-led, no Stripe price); yearly is

--- a/patches/changelog.txt
+++ b/patches/changelog.txt
@@ -1,3 +1,11 @@
+2026-07-24 (folder-chat notifications showed "Someone posted" with the viewer's
+  own avatar, and meeting start/end read the same; the teamchat rollup keyed on
+  the folder id so no author resolved. Carry the message author (author_id +
+  name) and a meeting_action (start/end, meeting takes priority over chat) so the
+  client shows "<user> posted / started / ended a meeting in <folder>" with the
+  right avatar. Additive columns only, read by name -> non-breaking.)
+  drumate/procedures/notification/notification_center_next.sql
+
 2026-07-23 (upload notification — root uploads showed the uploader email; fall
   back to the workspace name + carry the file name for single uploads)
   drumate/procedures/notification/notification_center_next.sql

--- a/patches/changelog.txt
+++ b/patches/changelog.txt
@@ -1,3 +1,7 @@
+2026-07-23 (upload notification — root uploads showed the uploader email; fall
+  back to the workspace name + carry the file name for single uploads)
+  drumate/procedures/notification/notification_center_next.sql
+
 2026-07-22 (task board — built-in columns only ever landed on the first board
   opened: task_column keyed on (id) alone while the built-ins are seeded per
   folder scope. Key becomes (id, nid), nid NOT NULL with '' for root; get /

--- a/patches/manifest.txt
+++ b/patches/manifest.txt
@@ -154,3 +154,4 @@
   yellow_page/procedures/meeting_schedule/meeting_schedule_mark_fired.sql
   yellow_page/procedures/contact/contact_storage_alert_unread.sql
   yellow_page/patches/2026-07-24-pricing-usd-team-business.sql
+  yellow_page/patches/2026-07-24-backfill-org-team-disk.sql

--- a/patches/manifest.txt
+++ b/patches/manifest.txt
@@ -155,3 +155,4 @@
   yellow_page/procedures/contact/contact_storage_alert_unread.sql
   yellow_page/patches/2026-07-24-pricing-usd-team-business.sql
   yellow_page/patches/2026-07-24-backfill-org-team-disk.sql
+  yellow_page/patches/2026-07-24-migrate-free-to-new-allowance.sql

--- a/patches/manifest.txt
+++ b/patches/manifest.txt
@@ -153,3 +153,4 @@
   yellow_page/procedures/meeting_schedule/meeting_schedule_due.sql
   yellow_page/procedures/meeting_schedule/meeting_schedule_mark_fired.sql
   yellow_page/procedures/contact/contact_storage_alert_unread.sql
+  yellow_page/patches/2026-07-24-pricing-usd-team-business.sql

--- a/yellow_page/patches/2026-07-24-backfill-org-team-disk.sql
+++ b/yellow_page/patches/2026-07-24-backfill-org-team-disk.sql
@@ -1,0 +1,30 @@
+-- Backfill: org rows still carrying the PRE-REBUILD per-seat allowance.
+--
+-- 2026-07-24-pricing-usd-team-business.sql rewrote quota rows whose plan was a
+-- retired NAME ('Pro', 'Drumee Plus', 'advanced'). Rows already named 'team'
+-- were left alone — but under the old model 'team' was PER SEAT, and
+-- payment_apply_entitlement stored `per-seat disk x seats`, typically the bare
+-- 50 GB per-seat figure. Those orgs read as Team while holding half the
+-- storage the plan now grants, and would only be corrected on their next
+-- renewal, whenever that happens to fall.
+--
+-- ONLY EVER RAISES. The disk is taken from the active catalog row and applied
+-- solely where the stored value is LOWER, so an org that legitimately holds
+-- more (a bigger negotiated allowance, a surviving storage add-on) keeps it.
+-- Nobody loses storage to this patch.
+--
+-- Idempotent: a second run matches nothing, because the values now agree.
+UPDATE `yp`.`quota` q
+  JOIN `yp`.`plan` p
+    ON p.plan_code = q.plan
+   AND p.entity_type = 'org'
+   AND p.active = 1
+   AND p.currency = 'usd'
+   AND p.period = 'month'
+   SET q.quota = JSON_SET(q.quota,
+         '$.disk', CAST(JSON_VALUE(p.quota, '$.disk') AS UNSIGNED),
+         '$.seat', CAST(JSON_VALUE(p.quota, '$.seat') AS UNSIGNED)),
+       q.mtime = UNIX_TIMESTAMP()
+ WHERE q.plan IN ('team', 'business')
+   AND CAST(IFNULL(JSON_VALUE(q.quota, '$.disk'), 0) AS UNSIGNED)
+       < CAST(JSON_VALUE(p.quota, '$.disk') AS UNSIGNED);

--- a/yellow_page/patches/2026-07-24-migrate-free-to-new-allowance.sql
+++ b/yellow_page/patches/2026-07-24-migrate-free-to-new-allowance.sql
@@ -1,0 +1,46 @@
+-- Migrate FREE rows still holding the pre-rebuild 20 GB onto the new 5 GB.
+--
+-- The pricing patch rewrote rows whose plan was a retired NAME, and the org
+-- backfill raised team/business disk. Neither touched `free`, which kept the
+-- old 20 GB allowance — so free accounts still read as Free while holding four
+-- times what the plan now grants.
+--
+-- WHY THIS ONE HAS A GUARD
+--   This is the only migration that REDUCES an allowance, and reducing below
+--   what someone already stores puts them instantly over quota: uploads start
+--   failing and the storage alerts fire, for a change they did not ask for.
+--   Measured on stage before writing this: of five rows still at 20 GB, one
+--   was storing 13 GB.
+--
+--   So a row is only lowered when the domain's live usage still fits in the new
+--   allowance. Accounts above it keep the larger figure and are listed by the
+--   SELECT below — they need a decision (grandfather, ask them to clear space,
+--   or offer an upgrade), not a silent squeeze.
+--
+-- Idempotent: rows already at the catalog value no longer match.
+UPDATE `yp`.`quota` q
+  JOIN `yp`.`plan` p
+    ON p.plan_code = 'free' AND p.entity_type = 'user'
+   AND p.active = 1 AND p.currency = 'usd'
+  LEFT JOIN `yp`.`quota_usage` qu ON qu.domain_id = q.domain_id
+   SET q.quota = JSON_SET(q.quota,
+         '$.disk',      CAST(JSON_VALUE(p.quota, '$.disk') AS UNSIGNED),
+         '$.desk_disk', CAST(JSON_VALUE(p.quota, '$.disk') AS UNSIGNED),
+         '$.hub_disk',  CAST(JSON_VALUE(p.quota, '$.disk') AS UNSIGNED)),
+       q.mtime = UNIX_TIMESTAMP()
+ WHERE q.plan = 'free'
+   AND CAST(IFNULL(JSON_VALUE(q.quota, '$.disk'), 0) AS UNSIGNED)
+       > CAST(JSON_VALUE(p.quota, '$.disk') AS UNSIGNED)
+   -- only where the live usage still fits the new allowance
+   AND IFNULL(qu.actual_usage, 0)
+       <= CAST(JSON_VALUE(p.quota, '$.disk') AS UNSIGNED);
+
+-- Left behind on purpose: free accounts storing more than the new allowance.
+-- Review these; they are NOT migrated by the statement above.
+SELECT q.payer_id, q.domain_id,
+       CAST(JSON_VALUE(q.quota, '$.disk') AS UNSIGNED) / 1000000000 AS current_gb,
+       ROUND(IFNULL(qu.actual_usage, 0) / 1000000000, 2)            AS used_gb
+  FROM `yp`.`quota` q
+  LEFT JOIN `yp`.`quota_usage` qu ON qu.domain_id = q.domain_id
+ WHERE q.plan = 'free'
+   AND CAST(IFNULL(JSON_VALUE(q.quota, '$.disk'), 0) AS UNSIGNED) > 5000000000;

--- a/yellow_page/patches/2026-07-24-pricing-usd-team-business.sql
+++ b/yellow_page/patches/2026-07-24-pricing-usd-team-business.sql
@@ -85,5 +85,12 @@ UPDATE `yp`.`quota`
        quota = JSON_OBJECT('plan','team','disk',100000000000,'seat',10,
                            'organization',1,'history_length',30),
        mtime = UNIX_TIMESTAMP()
- WHERE LOWER(plan) IN ('pro','drumee plus','advanced','company')
-   AND IFNULL(source,'') <> 'stripe';
+ WHERE LOWER(plan) IN ('pro','drumee plus','advanced','company');
+
+-- Deliberately NOT filtered on source. The first cut spared source='stripe'
+-- rows so a paying customer could never be rewritten — but that left rows
+-- pointing at a plan code the catalog no longer serves, which then has to be
+-- special-cased forever in the UI. Checked before widening: prod carries zero
+-- live Stripe subscriptions (3 rows, all mode='free', all expired), so no
+-- active payer exists to protect. Re-run safely: rows already on 'team' no
+-- longer match.

--- a/yellow_page/patches/2026-07-24-pricing-usd-team-business.sql
+++ b/yellow_page/patches/2026-07-24-pricing-usd-team-business.sql
@@ -1,0 +1,89 @@
+-- 2026-07 pricing rebuild: USD catalog, Pro (B2C) retired in favour of Team (B2B).
+--
+-- WHAT CHANGES
+--   FREE      $0     — 5 GB,   solo
+--   TEAM      $29/mo — 100 GB, up to 10 members   (the new entry paid tier)
+--   BUSINESS  $99/mo — 1 TB,   unlimited members  (sales-led, no Stripe price)
+--   SOVEREIGN        — self-hosted, sales-led, not a SaaS entitlement (absent here)
+--   Yearly = 11 x monthly (one month free): team $319, business $1089.
+--
+-- Prices themselves live in Stripe, not here — this file only carries the
+-- catalog rows and the quota each plan grants. stripe_price_id stays NULL and
+-- is seeded per environment out-of-band (sandbox and live are separate Stripe
+-- accounts, so price ids are never portable between them).
+--
+-- WHY `pro` GOES AWAY
+--   `pro` was the B2C per-user tier (entity_type='user', 5 included seats plus
+--   a `pro_seat` add-on). The product is now B2B: the entry paid tier is an
+--   ORGANISATION plan. So `team` becomes the first paid step and `pro`, along
+--   with every add-on (pro_seat, storage_*), is retired.
+--
+--   `team` also stops being per-seat. It used to price per seat and multiply
+--   quota.$.disk by the seat quantity; it is now a FLAT plan: 100 GB total for
+--   up to 10 members. payment_apply_entitlement is updated to match — see that
+--   procedure, the two must move together or org disk goes wrong.
+--
+-- SEAT SEMANTICS (unchanged where it matters)
+--   quota.$.seat stays "member slots", NOT a purchased quantity:
+--     free      0      — solo; existing code treats 0 as "cannot invite", so it
+--                        is deliberately left at 0 rather than 1.
+--     team      10
+--     business  100000 — effectively unlimited. A real number, not 0, so every
+--                        existing `if (!quota.seat)` / comparison keeps working;
+--                        0 would read as "no seats at all".
+--
+-- IDEMPOTENT + NON-DESTRUCTIVE:
+--   * INSERT IGNORE — re-running never clobbers env-specific stripe_price_id.
+--   * Retired rows are deactivated (active = 0), never deleted: subscription /
+--     renewal history FKs and audit trails still resolve their plan row.
+
+-- 1. New USD catalog ---------------------------------------------------------
+INSERT IGNORE INTO `yp`.`plan`
+  (plan_code, entity_type, period, currency, quota, features, active, stripe_price_id)
+VALUES
+  ('free','user','free','usd',
+   JSON_OBJECT('plan','free','disk',5000000000,'desk_disk',5000000000,'hub_disk',5000000000,
+               'seat',0,'organization',0,'history_length',0),
+   JSON_OBJECT(), 1, NULL),
+
+  -- TEAM — flat, NOT per-seat. quota.$.disk is the whole allowance.
+  ('team','org','month','usd',
+   JSON_OBJECT('plan','team','disk',100000000000,'seat',10,'organization',1,'history_length',30),
+   JSON_OBJECT(), 1, NULL),
+  ('team','org','year','usd',
+   JSON_OBJECT('plan','team','disk',100000000000,'seat',10,'organization',1,'history_length',30),
+   JSON_OBJECT(), 1, NULL),
+
+  -- BUSINESS — sales-led: rows exist so a manually provisioned org gets the
+  -- right entitlement, but stripe_price_id stays NULL (no self-serve checkout).
+  ('business','org','month','usd',
+   JSON_OBJECT('plan','business','disk',1000000000000,'seat',100000,'organization',1,'history_length',365),
+   JSON_OBJECT(), 1, NULL),
+  ('business','org','year','usd',
+   JSON_OBJECT('plan','business','disk',1000000000000,'seat',100000,'organization',1,'history_length',365),
+   JSON_OBJECT(), 1, NULL);
+
+-- 2. Retire the old catalog --------------------------------------------------
+-- Every EUR row: the currency of a Stripe price cannot be changed, so the USD
+-- rows above are new rows and the EUR ones must stop being selectable. The
+-- lookup procedures all filter `active = 1`, so this is the whole switch.
+UPDATE `yp`.`plan` SET active = 0 WHERE currency = 'eur';
+
+-- Pro and every add-on, in any currency.
+UPDATE `yp`.`plan` SET active = 0
+ WHERE plan_code IN ('pro','pro_seat','storage_100','storage_500','storage_1000','advanced','company');
+
+-- 3. Move legacy entitlements onto Team --------------------------------------
+-- Hand-granted rows predating the Stripe catalog carry free-text plan names
+-- ('Pro', 'Drumee Plus', 'advanced'). With `pro` retired they would point at a
+-- plan that no longer resolves, so they are moved onto the Team entitlement.
+-- Only rows NOT backed by a live Stripe subscription are touched (source is
+-- 'stripe' only for real subscriptions), so nothing a customer is paying for
+-- is rewritten by this patch.
+UPDATE `yp`.`quota`
+   SET plan  = 'team',
+       quota = JSON_OBJECT('plan','team','disk',100000000000,'seat',10,
+                           'organization',1,'history_length',30),
+       mtime = UNIX_TIMESTAMP()
+ WHERE LOWER(plan) IN ('pro','drumee plus','advanced','company')
+   AND IFNULL(source,'') <> 'stripe';

--- a/yellow_page/procedures/subscription/payment_apply_entitlement.sql
+++ b/yellow_page/procedures/subscription/payment_apply_entitlement.sql
@@ -19,15 +19,23 @@ BEGIN
 
   IF _entity_type = 'org' THEN
     -- Org: _entity_id = organisation id; entitlement keyed by the org's domain
-    -- so disk_limit tier-2 cascades it to all members. Per-seat: base disk =
-    -- seats * per-seat disk; total = base + storage add-ons.
+    -- so disk_limit tier-2 cascades it to all members.
+    --
+    -- FLAT, no longer per-seat (2026-07 pricing rebuild). Team grants 100 GB
+    -- for up to 10 members and Business 1 TB for unlimited — the plan's
+    -- quota.$.disk is the WHOLE allowance, so it must not be multiplied by the
+    -- subscription quantity any more, and quota.$.seat is the plan's member
+    -- CAP, so it must not be overwritten with the purchased quantity either.
+    -- _seats is kept in the signature for callers but no longer sizes anything;
+    -- see yellow_page/patches/2026-07-24-pricing-usd-team-business.sql, the two
+    -- have to move together or org disk goes wrong.
     SELECT domain_id FROM yp.organisation WHERE id = _entity_id LIMIT 1 INTO _domain_id;
     SET _domain_id = IFNULL(_domain_id, 1);
     SET _payer_id = _entity_id;
     SELECT quota FROM yp.plan WHERE plan_code = _plan_code AND entity_type = 'org' AND active = 1 LIMIT 1 INTO _plan_quota;
-    SET _plan_quota = IFNULL(_plan_quota, JSON_OBJECT('plan', _plan_code, 'disk', 50000000000));
-    SET _base_disk = IFNULL(JSON_VALUE(_plan_quota, '$.disk'), 50000000000) * _seats;
-    SET _plan_quota = JSON_SET(_plan_quota, '$.plan', _plan_code, '$.seat', _seats,
+    SET _plan_quota = IFNULL(_plan_quota, JSON_OBJECT('plan', _plan_code, 'disk', 100000000000, 'seat', 10));
+    SET _base_disk = IFNULL(JSON_VALUE(_plan_quota, '$.disk'), 100000000000);
+    SET _plan_quota = JSON_SET(_plan_quota, '$.plan', _plan_code,
                                '$.organization', 1, '$.disk', _base_disk + _extra_disk);
   ELSE
     -- Individual: payer-keyed row. total = plan disk + storage add-ons.

--- a/yellow_page/procedures/subscription/payment_get_catalog.sql
+++ b/yellow_page/procedures/subscription/payment_get_catalog.sql
@@ -11,6 +11,6 @@ BEGIN
   WHERE active = 1
     AND (_currency IS NULL OR _currency = '' OR currency = _currency)
     AND (_entity_type IS NULL OR _entity_type = '' OR entity_type = _entity_type)
-  ORDER BY FIELD(plan_code,'free','pro','advanced','company'), FIELD(period,'free','month','year');
+  ORDER BY FIELD(plan_code,'free','team','business'), FIELD(period,'free','month','year');
 END $
 DELIMITER ;

--- a/yellow_page/tables/plan.sql
+++ b/yellow_page/tables/plan.sql
@@ -20,26 +20,32 @@ CREATE TABLE IF NOT EXISTS `plan` (
 -- quota JSON MUST keep $.disk (+ $.desk_disk/$.hub_disk) — disk_limit/disk_free read those keys.
 -- stripe_price_id stays NULL here; real test price ids are set by a one-off data step (plan Task E1),
 -- NOT in this manifest seed, so a manifest re-run does not clobber them.
+-- 2026-07 pricing rebuild. Prices live in Stripe; this seeds only the catalog
+-- rows and the quota each plan grants. stripe_price_id stays NULL and is set
+-- per environment out-of-band — sandbox and live are separate Stripe accounts,
+-- so price ids are never portable between them.
+--
+--   FREE      $0     — 5 GB,   solo
+--   TEAM      $29/mo — 100 GB, up to 10 members   (entry paid tier, B2B)
+--   BUSINESS  $99/mo — 1 TB,   unlimited members  (sales-led, no Stripe price)
+--   Yearly = 11 x monthly (one month free): team $319, business $1089.
+--   SOVEREIGN is self-hosted and sales-led — not a SaaS entitlement, so absent.
+--
+-- quota.$.seat is a member CAP, not a purchased quantity: free 0 (solo; 0 also
+-- reads as "cannot invite" in existing code), team 10, business 100000
+-- (effectively unlimited, but a real number so `if (!quota.seat)` still works).
+--
+-- TEAM IS FLAT, not per-seat: quota.$.disk is the whole allowance and
+-- payment_apply_entitlement must not multiply it by the subscription quantity.
+-- The two move together.
+--
+-- The retired B2C catalog (pro, pro_seat, storage_* and every EUR row) is
+-- deactivated on existing DBs by
+-- yellow_page/patches/2026-07-24-pricing-usd-team-business.sql; a fresh DB
+-- simply never gets those rows.
 INSERT IGNORE INTO `plan` (plan_code,entity_type,period,currency,quota,features,active,stripe_price_id) VALUES
- ('free','user','free','eur', JSON_OBJECT('plan','free','disk',20000000000,'desk_disk',20000000000,'hub_disk',20000000000,'seat',0,'organization',0,'history_length',0), JSON_OBJECT(), 1, NULL),
- ('pro','user','month','eur', JSON_OBJECT('plan','pro','disk',50000000000,'desk_disk',50000000000,'hub_disk',50000000000,'seat',5,'organization',1,'history_length',7), JSON_OBJECT(), 1, NULL),
- ('pro','user','year','eur',  JSON_OBJECT('plan','pro','disk',50000000000,'desk_disk',50000000000,'hub_disk',50000000000,'seat',5,'organization',1,'history_length',7), JSON_OBJECT(), 1, NULL),
- -- P3 org/team: PER-SEAT. quota.disk here is the PER-SEAT allowance;
- -- payment_apply_entitlement multiplies it by the seat quantity. desk_disk/
- -- hub_disk are omitted so disk_limit's IFNULL falls back to the scaled disk.
- ('team','org','month','eur', JSON_OBJECT('plan','team','disk',50000000000,'seat',0,'organization',1,'history_length',30), JSON_OBJECT(), 1, NULL),
- ('team','org','year','eur',  JSON_OBJECT('plan','team','disk',50000000000,'seat',0,'organization',1,'history_length',30), JSON_OBJECT(), 1, NULL),
- -- P4 storage add-ons (entity_type='addon'): a recurring line-item on the
- -- subscription; the reducer sums their $.disk into the entitlement's extra_disk.
- -- One price per period (Stripe requires add-on interval = subscription interval).
- ('storage_100','addon','month','eur',  JSON_OBJECT('plan','storage_100','disk',100000000000), JSON_OBJECT(), 1, NULL),
- ('storage_100','addon','year','eur',   JSON_OBJECT('plan','storage_100','disk',100000000000), JSON_OBJECT(), 1, NULL),
- ('storage_500','addon','month','eur',  JSON_OBJECT('plan','storage_500','disk',500000000000), JSON_OBJECT(), 1, NULL),
- ('storage_500','addon','year','eur',   JSON_OBJECT('plan','storage_500','disk',500000000000), JSON_OBJECT(), 1, NULL),
- ('storage_1000','addon','month','eur', JSON_OBJECT('plan','storage_1000','disk',1000000000000), JSON_OBJECT(), 1, NULL),
- ('storage_1000','addon','year','eur',  JSON_OBJECT('plan','storage_1000','disk',1000000000000), JSON_OBJECT(), 1, NULL),
- -- C1 Pro per-seat: Pro includes quota.$.seat seats (5); extra seats are a
- -- recurring add-on line item (quantity = extra seats). $.seat=1 marks one
- -- seat per unit; no $.disk — seats don't add storage on Pro.
- ('pro_seat','addon','month','eur', JSON_OBJECT('plan','pro_seat','seat',1), JSON_OBJECT(), 1, NULL),
- ('pro_seat','addon','year','eur',  JSON_OBJECT('plan','pro_seat','seat',1), JSON_OBJECT(), 1, NULL);
+ ('free','user','free','usd', JSON_OBJECT('plan','free','disk',5000000000,'desk_disk',5000000000,'hub_disk',5000000000,'seat',0,'organization',0,'history_length',0), JSON_OBJECT(), 1, NULL),
+ ('team','org','month','usd', JSON_OBJECT('plan','team','disk',100000000000,'seat',10,'organization',1,'history_length',30), JSON_OBJECT(), 1, NULL),
+ ('team','org','year','usd',  JSON_OBJECT('plan','team','disk',100000000000,'seat',10,'organization',1,'history_length',30), JSON_OBJECT(), 1, NULL),
+ ('business','org','month','usd', JSON_OBJECT('plan','business','disk',1000000000000,'seat',100000,'organization',1,'history_length',365), JSON_OBJECT(), 1, NULL),
+ ('business','org','year','usd',  JSON_OBJECT('plan','business','disk',1000000000000,'seat',100000,'organization',1,'history_length',365), JSON_OBJECT(), 1, NULL);


### PR DESCRIPTION
2026-07 pricing rebuild — **USD catalog, and the B2C `pro` tier gives way to the B2B `team` tier**. Ships across three repos on the same branch name; merge together.

| | FREE | TEAM | BUSINESS | SOVEREIGN |
| :-- | :-- | :-- | :-- | :-- |
| Monthly | $0 | **$29** | $99 | from $499 |
| Yearly (**11 × monthly**, one month free) | — | **$319** | $1089 | — |
| Storage | 5 GB | 100 GB | 1 TB | your infra |
| Members | solo | up to 10 | unlimited | unlimited |
| Sold how | — | **self-serve Stripe** | sales-led | sales-led |

Only **Team** has a Stripe price. Business and Sovereign are sales-led: their CTA opens the contact-sales notice, because routing them to checkout would dead-end on `NO_PRICE`.

## Why `pro` goes away

`pro` was the B2C per-user tier (`entity_type='user'`, 5 included seats plus a `pro_seat` add-on). The product is B2B now, so the entry paid tier is an **organisation** plan. Pro and every add-on (`pro_seat`, `storage_*`) are retired.

**Team also stops being per-seat.** It used to price per seat and multiply `quota.$.disk` by the seat quantity; it is flat now — 100 GB for up to 10 members. The catalog rows and `payment_apply_entitlement` have to move together or org disk goes wrong.

## Notable decisions

- **Retired rows are deactivated, never deleted** — subscription and renewal history still resolves its plan row. Every lookup procedure already filters `active = 1`, which is the whole switch.
- **EUR rows are deactivated, not converted.** A Stripe price's currency cannot be changed, so the USD rows are new rows.
- **`quota.$.seat` is a member CAP, not a purchased quantity.** Free stays `0` (existing code reads 0 as "cannot invite"); Business uses a real large number, because `0` would read as no seats at all.
- **Checkout sends quantity 1.** Passing a seat total would multiply the bill on a flat plan.
- **Legacy entitlements move to Team.** Hand-granted rows carry free-text names (`Pro`, `Drumee Plus`) that would point at a retired plan. Only rows whose `source` is not `stripe` are rewritten, so nothing a customer pays for is touched. Verified first: **prod has zero live Stripe subscriptions** (3 rows, all `mode=free`, expired) and 14 such legacy rows.
- The FE folds `pro` / `Drumee Plus` onto Team as well, so any row the patch deliberately skipped still displays coherently. For the same reason `pro` is dropped from `needsAdminConsoleUpgrade` — those users are entitled to the console now.

## Verified on stage (live, end-to-end)

Patch applied, Stripe sandbox seeded (`prod_UwZPe8yNGwH8g5`), server synced + restarted, FE rebuilt:

- Catalog returns 5 rows, all `usd` — no EUR, no `pro`, no add-ons.
- Team amounts read **live from Stripe**: `$29` / `$319`. Business + Sovereign return no amount and no price id, as intended.
- Cards render **Free · Team · Business · Sovereign Node** at **$0 · $29 · $99 · $499**.
- An account whose quota still says `pro` resolves to `currentPlanName = "team"` — the alias works.

Not yet done: a real test-card checkout run, and Stripe **live** (deliberately out of scope — stage only).
